### PR TITLE
Add "edit" script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 _site
 .jekyll-cache/
 Gemfile.lock
+
+vendor/
+
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ branch; then pull from the original CHTC Github repository:
 
 ## Testing Changes Locally
 
+### Quickstart (Unix Only)
+
+1. Install Docker if you don't already have it on your computer.
+2. Open a terminal and `cd` to your local copy of the `chtc-website-source` repository
+3. Run the `./edit.sh` script.
+4. The website should appear at [http://localhost:8080](http://localhost:8080). Note that this system is missing the secret sauce of our setup that converts 
+the pages to an `.shtml` file ending, so links won't work but just typing in the name of a page into the address bar (with no 
+extension) will. 
+
+### Run Docker Manually
+
 1. Install Docker if you don't already have it on your computer and open a terminal. 
 2. Pull the `jekyll` container
 
@@ -57,7 +68,7 @@ branch; then pull from the original CHTC Github repository:
 		docker run -it --rm=true -v $PWD:/srv/jekyll --publish 8080:8080 jekyll/jekyll jekyll serve -P 8080
 	The first time you do this, you'll have to wait for about 3-5 minutes for jekyll to 
 build all its dependencies and then render the website. 
-5. The website should appear at `localhost:8080`. Note that this system is missing the secret sauce of our setup that converts 
+5. The website should appear at [http://localhost:8080](http://localhost:8080). Note that this system is missing the secret sauce of our setup that converts 
 the pages to an `.shtml` file ending, so links won't work but just typing in the name of a page into the address bar (with no 
 extension) will. 
 

--- a/edit.sh
+++ b/edit.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+mkdir -p "$PWD/vendor/bundle"
+
+docker run \
+  -it --rm \
+  --mount type=bind,source="$PWD",target=/srv/jekyll \
+  --mount type=bind,source="$PWD/vendor/bundle",target=/usr/local/bundle \
+  --publish 8080:8080 \
+  jekyll/jekyll \
+  jekyll serve -P 8080 $*


### PR DESCRIPTION
- adds an `edit.sh` script that embeds the `docker run` command (including caching the bundler install that happens inside the container!)
- updates `.gitignore` accordingly (and also adds some common IDE setting directory ignores, for future safety) 
- updates `README.txt` accordingly