### PR TITLE
Add CHTC GPU Lab policies and opt-in instructions

### DIFF
--- a/gpu-jobs.shtml
+++ b/gpu-jobs.shtml
@@ -5,14 +5,14 @@ title: Jobs That Use GPUs
 
 <h1>Overview</h1>
 
-<p>GPUs (Graphical Processing Units) are a special kind of computer processor 
-that are optimized for running very large numbers of simple calculations in 
-parallel, which often can be applied to problems related to image processing or 
-machine learning. Well-crafted GPU programs for suitable applications can 
-outperform implementations running on CPUs by a factor of ten or more, <i>but 
-only when the program is written and designed explicitly to run on GPUs using 
-special libraries like CUDA</i>. For researchers who have problems that are 
-well-suited to GPU processing, it is possible to run jobs that use GPUs in CHTC.   
+<p>GPUs (Graphical Processing Units) are a special kind of computer processor
+that are optimized for running very large numbers of simple calculations in
+parallel, which often can be applied to problems related to image processing or
+machine learning. Well-crafted GPU programs for suitable applications can
+outperform implementations running on CPUs by a factor of ten or more, <i>but
+only when the program is written and designed explicitly to run on GPUs using
+special libraries like CUDA</i>. For researchers who have problems that are
+well-suited to GPU processing, it is possible to run jobs that use GPUs in CHTC.
 Read on to determine:</p>
 
 <ol>
@@ -23,16 +23,16 @@ Read on to determine:</p>
 </ol>
 
 <blockquote>
-This is the initial version of a guide about running GPU jobs in CHTC.  If 
-you have any suggestions for improvement, or any questions about using GPUs 
+This is the initial version of a guide about running GPU jobs in CHTC.  If
+you have any suggestions for improvement, or any questions about using GPUs
 in CHTC, please email the research computing facilitators at chtc@cs.wisc.edu.
 </blockquote>
 
 <a name="gpus"></a>
 <h1>1. GPUs Available in CHTC</h1>
 
-<p>CHTC's high throughput (HTC) system 
-has the following servers with GPU capabilities that are available to 
+<p>CHTC's high throughput (HTC) system
+has the following servers with GPU capabilities that are available to
 any CHTC user (as of 2/7/2020):</p>
 <br>
 
@@ -46,10 +46,10 @@ any CHTC user (as of 2/7/2020):</p>
     <th>HasCHTCStaging</th>
   </tr>
 <!--  <tr>
-    <td>gpu-3.chtc.wisc.edu</td> 
+    <td>gpu-3.chtc.wisc.edu</td>
     <td>1 </td>
     <td>Tesla K40c</td>
-  </tr>   -->  
+  </tr>   -->
   <tr>
     <td>2</td>
     <td>gpu2000, gpu2001</td>
@@ -76,38 +76,38 @@ any CHTC user (as of 2/7/2020):</p>
   </tr>
 </table>
 
-<p>CHTC has plans to increase our GPU capacity through the <a href="/gpu-lab.shtml">CHTC GPU 
-Lab</a> project, funded by UW2020. This page will be updated as we acquire additional 
+<p>CHTC has plans to increase our GPU capacity through the <a href="/gpu-lab.shtml">CHTC GPU
+Lab</a> project, funded by UW2020. This page will be updated as we acquire additional
 GPU capacity. </p>
 
-<p>You can also find out information about GPUs in CHTC through the 
-<code>condor_status</code> command.  All of our servers with GPUs have 
-a <code>TotalGPUs</code> attribute that is greater than zero; thus we can 
+<p>You can also find out information about GPUs in CHTC through the
+<code>condor_status</code> command.  All of our servers with GPUs have
+a <code>TotalGPUs</code> attribute that is greater than zero; thus we can
 query the pool to find GPU-enabled servers by running: </p>
 
 <pre class="term">[alice@submit]$ condor_status -compact -constraint 'TotalGpus > 0'</pre>
 
 <blockquote><b>Why are there more GPU servers in condor_status?</b><br>
 
-If you run the <code>condor_status</code> command above, you'll see more servers listed 
-than we show in the table above. Some of these servers have been purchased for specific 
-research groups and are prioritized for their group members. If you set the submit 
-file option <code>+WantFlocking</code> to true, your jobs are eligible to run on all 
-GPU servers in CHTC, 
-but they are no longer guaranteed a 72-hour run time. 
+If you run the <code>condor_status</code> command above, you'll see more servers listed
+than we show in the table above. Some of these servers have been purchased for specific
+research groups and are prioritized for their group members. If you set the submit
+file option <code>+WantFlocking</code> to true, your jobs are eligible to run on all
+GPU servers in CHTC,
+but they are no longer guaranteed a 72-hour run time.
 
 </blockquote>
 
-<p>To print out specific information about a GPU server and its GPUs, you can use the 
-"auto-format" option for <code>condor_status</code> and the 
-names of specific server attributes.  For example, the table above can be mostly recreated 
+<p>To print out specific information about a GPU server and its GPUs, you can use the
+"auto-format" option for <code>condor_status</code> and the
+names of specific server attributes.  For example, the table above can be mostly recreated
 using the attributes
-<code>Machine</code>, <code>TotalGpus</code> and <code>CUDADeviceName</code>: 
+<code>Machine</code>, <code>TotalGpus</code> and <code>CUDADeviceName</code>:
 
 <pre class="term">[alice@submit]$ condor_status -compact -constraint 'TotalGpus > 0' -af Machine TotalGpus CUDADeviceName
 </pre>
 
-<p>In addition, HTCondor tracks other GPU-related attributes for each 
+<p>In addition, HTCondor tracks other GPU-related attributes for each
 server, including: </p>
 
 <table class="gtable">
@@ -129,8 +129,8 @@ server, including: </p>
 	</tr>
 	<tr>
 		<td><code>CUDACapability</code></td>
-		<td>Represents various capabilities of the GPU. Can be used as a proxy for the GPU card type when 
-		requiring a specific type of GPU. More details on what the capability numbers mean can be found on the 
+		<td>Represents various capabilities of the GPU. Can be used as a proxy for the GPU card type when
+		requiring a specific type of GPU. More details on what the capability numbers mean can be found on the
 		<a href="https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#compute-capabilities">
 		NVIDIA website</a>.</td>
 	</tr>
@@ -145,10 +145,10 @@ server, including: </p>
 </table>
 
 
-<!-- 
+<!--
 
-<p>To see this information printed out, add the attributes you want to the 
-<code>condor_status</code> command shown above.  A sample command (and output) 
+<p>To see this information printed out, add the attributes you want to the
+<code>condor_status</code> command shown above.  A sample command (and output)
 might look like this: </p>
 
 <pre class="term">[alice@submit]$ condor_status -constraint 'TotalGpus > 0' -af Name Gpus CUDADeviceName Cpus Memory
@@ -166,14 +166,14 @@ slot1_7@gzk-2.chtc.wisc.edu 1 GeForce GTX 1080 1 1024
 slot1_8@gzk-2.chtc.wisc.edu 1 GeForce GTX 1080 1 1024
 </pre>
 
-<p>In the output above "slot1" represents the remaining available resources on 
-a server; if a server isn't running any jobs, this slot will show the total 
-resources available on that server.  As jobs start, their resources are taken 
-away from "slot1" to run individual jobs, which you can see in "slot1_1" etc. 
+<p>In the output above "slot1" represents the remaining available resources on
+a server; if a server isn't running any jobs, this slot will show the total
+resources available on that server.  As jobs start, their resources are taken
+away from "slot1" to run individual jobs, which you can see in "slot1_1" etc.
 above.</p>
 
-<p>To see all possible attributes for a particular server, you can use the "long" option with 
-<code>condor_status</code> and the name of the server/slot you want to see: 
+<p>To see all possible attributes for a particular server, you can use the "long" option with
+<code>condor_status</code> and the name of the server/slot you want to see:
 <pre class="term">[alice@submit]$ condor_status -l slot1@gpu-0000.chtc.wisc.edu</pre>
 </p> -->
 
@@ -182,22 +182,22 @@ above.</p>
 
 <h2>A. Request GPUs (required)</h2>
 
-<p>All jobs that use GPUs must request GPUs in their submit file (along with 
+<p>All jobs that use GPUs must request GPUs in their submit file (along with
 the usual requests for CPUs, memory and disk). </p>
 
 <pre class="sub">request_gpus = 1</pre>
 
-<p>It is important to still request at least one CPU per job to do the processing 
+<p>It is important to still request at least one CPU per job to do the processing
 that is not well-suited to the GPU.</p>
 
-<p>Note that HTCondor will make sure your job has access to the GPU -- you shouldn't 
-need to set any environmental variables or other options related to the GPU, except 
+<p>Note that HTCondor will make sure your job has access to the GPU -- you shouldn't
+need to set any environmental variables or other options related to the GPU, except
 what is needed inside your code.</p>
 
 <h2>B. Request specific GPUs or CUDA functionality (optional)</h2>
 
-<p>If your software or code requires a specific version of CUDA, a certain type of 
-GPU, or has some other special requirement, you will need to add a "requirements" 
+<p>If your software or code requires a specific version of CUDA, a certain type of
+GPU, or has some other special requirement, you will need to add a "requirements"
 statement to your submit file that uses one of the attributes shown above. </p>
 
 <p>If you want a certain class of GPU, use CUDACapability:</p>
@@ -222,20 +222,20 @@ statement to your submit file that uses one of the attributes shown above. </p>
 </table>
 
 <blockquote>
-<p>It may be tempting to add requirements for specific GPU servers or types 
-of GPU cards.  However, when possible, it is best to write your code 
-so that it can run across 
+<p>It may be tempting to add requirements for specific GPU servers or types
+of GPU cards.  However, when possible, it is best to write your code
+so that it can run across
 GPU types and without needing the latest version of CUDA.  </p>
 </blockquote>
 
 <h2>C. Access shared and research group GPUs (optional)</h2>
 
-<p>As alluded to above, certain GPU servers in CHTC are prioritized for the research 
-groups that own them, but are available to run other jobs when not being used by their 
-owners. When running on these servers, jobs forfeit our otherwise guaranteed runtime 
-of 72 hours; however, for shorter jobs, this is not a drawback and allowing jobs to run 
-on these additional servers opens up more capacity. To allow jobs to run on these 
-research-group owned servers if there is space, add the "Flocking" option to your submit file: 
+<p>As alluded to above, certain GPU servers in CHTC are prioritized for the research
+groups that own them, but are available to run other jobs when not being used by their
+owners. When running on these servers, jobs forfeit our otherwise guaranteed runtime.
+However, for shorter jobs, this is not a drawback and allowing jobs to run
+on these additional servers opens up more capacity. To allow jobs to run on these
+research-group owned servers if there is space, add the "Flocking" option to your submit file:
 </p>
 
 <pre class="sub">
@@ -244,58 +244,66 @@ research-group owned servers if there is space, add the "Flocking" option to you
 
 <h2>D. Use the <code>gzk</code> servers (optional)</h2>
 
-<p>The default operating system for jobs in CHTC is now CentOS 7. <b>If you 
-want to use the <code>gzk-*</code> GPU nodes shown above, you'll need to specifically 
-request the use of Scientific Linux 6 as an operating system.</b> There is 
+<p>The default operating system for jobs in CHTC is now CentOS 7. <b>If you
+want to use the <code>gzk-*</code> GPU nodes shown above, you'll need to specifically
+request the use of Scientific Linux 6 as an operating system.</b> There is
 an example of how to do this in our <a href="/os-transition.shtml">Operating System guide</a>.
+</p>
+
+<h2>E. Use the CHTC GPU Lab servers (optional)</h2>
+
+<p>The CHTC GPU Lab offers shared GPUs available to any CHTC user. However, this resource has
+different runtime and other policies than general CHTC servers. See the <a href="/gpu-lab.shtml">
+CHTC GPU Lab</a> page for policy information and submit file modifications required to opt-in to
+use the GPU Lab servers.
 </p>
 
 <a name="software"></a>
 <h1>3. Software Considerations</h1>
 
-<p>Before using GPUs in CHTC you should ensure that the use of GPUs will 
-actually help your program run faster.  This means that the code or software 
-you are using has the special programming required to use GPUs and that 
+<p>Before using GPUs in CHTC you should ensure that the use of GPUs will
+actually help your program run faster.  This means that the code or software
+you are using has the special programming required to use GPUs and that
 your particular task will use this capability.</p>
 
 <p>If this is the case, there are several ways to run GPU-enabled software
 in CHTC: </p>
 
 <blockquote><b>Machine Learning</b><br>
-For those using machine learning code specifically, we have a guide with 
+For those using machine learning code specifically, we have a guide with
 more specific recommendations here: <a href="/machine-learning-htc.shtml">Run Machine Learning Jobs on HTC</a>
 </blockquote>
 
 <h2>A. Compiled Code</h2>
 
-<p>You can use our conventional methods of creating a portable installation 
-of a software package (as in our R/Python guides) to run on GPUs.  Most of our 
-build servers or GPU servers have copies of the CUDA Runtime that can be used 
-to compile code. To access these servers, submit an interactive job, following the 
-instructions in our <a href="/inter-submit">Build Job Guide</a> or by submitting 
-a GPU job submit file with the interactive flag for <code>condor_submit</code>. Once 
+<p>You can use our conventional methods of creating a portable installation
+of a software package (as in our R/Python guides) to run on GPUs.  Most of our
+build servers or GPU servers have copies of the CUDA Runtime that can be used
+to compile code. To access these servers, submit an interactive job, following the
+instructions in our <a href="/inter-submit">Build Job Guide</a> or by submitting
+a GPU job submit file with the interactive flag for <code>condor_submit</code>. Once
 on a build or GPU server, see what CUDA versions are available by looking at
  the path <code>/user/local/cuda-*</code>. </p>
 
-<p>Note that we strongly recommend software installation strategies that incorporate 
-the CUDA runtime into the final installed code, so that jobs are able to run on servers 
-even if a different version of the CUDA runtime is installed (or there's no runtime at all!). 
-For compiled code, look for flags that enable static linking or use one of the solutions listed below. 
+<p>Note that we strongly recommend software installation strategies that incorporate
+the CUDA runtime into the final installed code, so that jobs are able to run on servers
+even if a different version of the CUDA runtime is installed (or there's no runtime at all!).
+For compiled code, look for flags that enable static linking or use one of the solutions listed below.
 </p>
 
 <h2>B. Docker</h2>
 
-<p>CHTC's GPU servers have "nvidia-docker" installed, a specific 
-version of Docker that integrates Docker containers with GPUs.  If you 
-can find or create a Docker image with your software that is based on 
-the nvidia-docker container, you can use this to run your jobs in 
-CHTC.  See our <a href="/docker-jobs.shtml">Docker guide</a> for 
+<p>CHTC's GPU servers have "nvidia-docker" installed, a specific
+version of Docker that integrates Docker containers with GPUs.  If you
+can find or create a Docker image with your software that is based on
+the nvidia-docker container, you can use this to run your jobs in
+CHTC.  See our <a href="/docker-jobs.shtml">Docker guide</a> for
 how to use Docker in CHTC.</p>
 
 <a name="osg"></a>
 <h1>4. Using GPUs on the Open Science Grid</h1>
 
-<p>CHTC, as a member of the Open Science Grid (OSG) can access GPUs that 
-are available on the OSG.  See <a href="/scaling-htc.shtml">this guide</a> to know whether your jobs are 
-good candidates for the OSG and then get in touch with CHTC's Research Computing 
+<p>CHTC, as a member of the Open Science Grid (OSG) can access GPUs that
+are available on the OSG.  See <a href="/scaling-htc.shtml">this guide</a> to know whether your jobs are
+good candidates for the OSG and then get in touch with CHTC's Research Computing
 Facilitators to discuss details. </p>

--- a/gpu-lab.md
+++ b/gpu-lab.md
@@ -34,15 +34,60 @@ computing infrastructure at UW-Madison.  It will include:
 If you want to use GPU resources in CHTC for your research: 
 
 - Apply for a CHTC account if you do not already have one: [Account Request Page][account]
-- See what GPUs are available and how to use them in the [GPU jobs guide][gpu-jobs].
+- See what GPUs are available and how to use them in the [GPU jobs guide][gpu-jobs]
+- See the instructions below to opt-in to use the CHTC GPU Lab servers
 - See our guide with specific machine learning related tips: [Running Machine Learning Jobs on HTC][ml-guide]
-- For more extended examples, see the following: [Runnable examples on GitHub][gpu-examples].
+- For more extended examples, see the following: [Runnable examples on GitHub][gpu-examples]
 
 The CHTC GPU Lab mailing list is used to announce new GPU hardware availability and 
 GPU-related events, solicit feedback from GPU users, and share best practices for 
 GPU computing in CHTC. Any CHTC user can subscribe to the list by 
 emailing [join-chtc-gpu-lab@lists.wisc.edu](mailto:join-chtc-gpu-lab@lists.wisc.edu).
 Their subscription request will be reviewed by the list administrators.
+
+## CHTC GPU Lab policies
+
+There are a limited number of shared use GPUs available through the CHTC GPU
+Lab. Therefore, these servers have different policies about job runtimes and
+the maximum number of running jobs per user than general CHTC servers.
+These GPUs are a special investment from the UW2020 program, and the policies
+aim to maximize how many researchers can benefit from this investment.
+
+By opting-in to use the CHTC GPU Lab servers, you agree to be contacted by the
+project leaders occasionally to discuss your GPU computing and help improve the
+GPU Lab.
+
+### Job types, runtimes, and per-user limitations
+
+{:.gtable}
+  | Job type | Submit file name (?) | Maximum runtime | Per-user limitation |
+  | --- |
+  | Short | ? | 12 hrs | 2/3 of CTHC GPU Lab GPUs |
+  | Medium | ? | 24 hrs | 1/3 of CTHC GPU Lab GPUs |
+  | Long | ? | 7 days | 1 job with 1-2 GPUs |
+  | Interactive | ? | 4 hours | 1 job with 1 GPU |
+  | Pre-emptable (backfill) | ? | None | None |
+
+These job types, runtimes, and per-user limitations are subject to change with
+short notice as the CHTC GPU Lab studies usage patterns.
+
+### Modifying the submit file
+
+To accept the CHTC GPU Lab policies and opt-in to use these GPUs, add the
+following line to your submit file:
+
+``` {.sub}
++WantGPULab = true
+```
+**<todo: finalize the syntax>**
+
+To specify the job type... **<todo: finalize the syntax>**
+
+``` {.sub}
+???
+```
+
+If you do not specify a job type, the Medium job type will be used as the default.
 
 > The CHTC GPU Lab is led by Anthony Gitter, Lauren Michael, Brian Bockelman, and Miron Livny.
 


### PR DESCRIPTION
This is a work-in-progress until we finalize the syntax for the submit file modifications.  Once that is determined we can work on https://github.com/CHTC/templates-GPUs/issues/5

My text editor deleted trailing whitespace in `gpu-jobs.shtml`.  I can revert and use a different editor if that is distracting.

@lmichael107 @bbockelm does this accurately reflect our discussions?

@ChristinaLK what do you think about how the GPU Lab updates should interact with the main GPU page? I made some edits. However, almost all of the shared use GPUs in CHTC will be available through the GPU Lab in the near future. Should we promote these instructions more heavily?