### PR TITLE
Fixing du/df typo

### DIFF
--- a/HPCuseguide.md
+++ b/HPCuseguide.md
@@ -434,7 +434,7 @@ info here: <https://lintut.com/ncdu-check-disk-usage/>
 The command `du` can also be used to examine the size of directories:
 
 ```
-[alice@service]$ du -h /home/alice
+[alice@service]$ du -sh /home/alice
 ```
 {:.term}
 

--- a/HPCuseguide.md
+++ b/HPCuseguide.md
@@ -433,8 +433,8 @@ info here: <https://lintut.com/ncdu-check-disk-usage/>
 
 The command `du` can also be used to examine the size of directories:
 
-``` 
-[alice@service]$ df -h /home/alice
+```
+[alice@service]$ du -h /home/alice
 ```
 {:.term}
 


### PR DESCRIPTION
Closes #64 
I found this typo while going through the guides, nothing major, might be a little confusing for someone who doesn't know the difference between `df` and `du` however.