### PR TITLE
R build guide

### DIFF
--- a/r-build.md
+++ b/r-build.md
@@ -105,6 +105,8 @@ command to include the flag** `--with-pcre1`
 (e.g. `./configure --prefix=$_CONDOR_SCRATCH_DIR/R --with-pcre1`).
 
 ```
+[user@build]$ touch doc/NEWS.2.rds
+[user@build]$ touch doc/NEWS.3.rds
 [user@build]$ ./configure --prefix=$_CONDOR_SCRATCH_DIR/R
 [user@build]$ make
 [user@build]$ make install

--- a/r-build.md
+++ b/r-build.md
@@ -9,7 +9,7 @@ title: Building R in HTC
 **This guide will provide instructions for compiling base R from source code and is intended 
 for compiling versions of R that are currently not provided via the CHTC Squid Web Proxy**
 
-Before compiling R, please take a moment to review our [R Jobs](http://chtc.cs.wisc.edu/r-jobs.shtml) guide to see what versions of R are currently available on the HTC.
+Before compiling R, please take a moment to review our [R Jobs](/r-jobs.shtml) guide to see what versions of R are currently available on the HTC.
 
 **To best understand the below information, you 
 should already have an understanding of how to:**
@@ -51,7 +51,7 @@ the submit server (so that you can use the R installation for later jobs).
 
 To submit an interactive job, create a submit file called `build.sub` as shown below:
 
-``` {.sub}
+``` {:.sub}
 # build.sub
 # Software build file
 
@@ -68,7 +68,7 @@ request_memory = 4GB
 request_disk = 4GB
 
 queue
-```
+``` {:.sub}
 
 Be sure to modify the above `transfer_input_files` statement with the appropriate 
 name of the R source code that you downloaded in the previous ste.
@@ -114,23 +114,23 @@ Then return the the top level directory:
 ```
 [alice@build]$ cd ../
 ```
-{.term}
+{:.term}
 
 If R has been installed successfully, you should be able to run the following command as a test:
 
 ```
 [alice@build]$ R/bin/R --version
 ```
-{.term}
+{:.term}
 
 The output of the above command should match the version number that you just installed!
 
 ## 4. Install Packages 
 
 After your R compilation has completed, if any additional R packages are required for your work, 
-please follow the steps in our [R Jobs](http://chtc.cs.wisc.edu/r-jobs.shtml) guide 
+please follow the steps in our [R Jobs](/r-jobs.shtml) guide 
 starting with the `export` commands shown in step 
-[1.B.1](http://chtc.cs.wisc.edu/r-jobs.shtml#b.-install-the-packages). After creating a compressed tar 
+[1.B.1](/r-jobs.shtml#b.-install-the-packages). After creating a compressed tar 
 archive of your `packages` directory return the the next steps in this guide.
 
 ## 5. Create A Portable Copy of Your R Installation
@@ -141,17 +141,17 @@ is to create a compressed tar archive of your R installation. From the top level
 ```
 [alice@build]$ tar czf my_R#.#.#.tar.gz R/
 ```
-{.term}
+{:.term}
 
 **Be sure to check the size of your R tar archive:**
 ```
 [alice@build]$ ls -lh my_R#.#.#.tar.gz
 ```
-{.term}
+{:.term}
 
 **If the size of `my_R#.#.#.tar.gz` is larger than ~100MB then your will need to use 
 the CHTC Squid Wed Proxy to host this file.** See our 
-[Squid Web Proxy](http://chtc.cs.wisc.edu/file-avail-squid.shtml) guide for more details.
+[Squid Web Proxy](/file-avail-squid.shtml) guide for more details.
 
 Now you have a portable copy of your R installation that can be brought along with your jobs. 
 The final step is to terminate your interactive job, and HTCondor will tranfer your R tar archive 
@@ -160,7 +160,7 @@ back to your `/home` directory:
 ```
 [alice@submit]$ exit
 ```
-{.term}
+{:.term}
 
 Once your interactive job terminates, you will be back in your `/home` directory on the submit 
 server and should see a copy of your R tar archive:
@@ -168,9 +168,11 @@ server and should see a copy of your R tar archive:
 ```
 [alice@submit]$ ls
 ```
-{.term}
+{:.term}
 
 ## 6. Use Your Custom R Installation In Your Jobs
 
 To use the R installation that was built using the steps in this guide, please follow 
-the steps and examples described on our [R Jobs](http://chtc.cs.wisc.edu/r-jobs.shtml) guide.
+the steps and examples described on our [R Jobs](/r-jobs.shtml) guide, **however 
+you will need to modify `transfer_input_files` in your submit file to specify your `R#.#.#.tar.gz` 
+tar archive instead of transferring a copy of R from the Squid web proxy.**

--- a/r-build.md
+++ b/r-build.md
@@ -99,9 +99,9 @@ To install R, first create a directory that will hold your R installation (e.g. 
 ```
 {:.term}
 
-From the source code directory, run the following commands. **The `make` step may take a while to 
-complete!** If building R version 4.x.x or higher you will need to modify the below `configure` 
-command to include the flag `--with-pcre1` 
+From the source code directory, run the following commands. The `make` step may take a while to 
+complete! **If building R version 4.x.x or higher you will need to modify the below `configure` 
+command to include the flag** `--with-pcre1` 
 (e.g. `./configure --prefix=$_CONDOR_SCRATCH_DIR/R --with-pcre1`).
 
 ```

--- a/r-build.md
+++ b/r-build.md
@@ -20,12 +20,12 @@ should already have an understanding of how to:**
 
 This guide details the steps needed to: 
 
- 1. [Download R source code](#1.-download-r-source-code) 
- 2. [Submit an interactive job to a build server](#2.-submit-an-interactive-job-to-a-build-server) 
- 3. [Compile base R from source code](#3.-compile-base-r-from-source-code) 
- 4. [Install additional R packages](#4.-install-packages) 
- 5. [Create a portable copy of your R installation that can be brought along with your jobs](#5.-create-a-portable-copy-of-your-r-installation)
- 6. [Use your custom R installation in your jobs](#6.-use-your-custom-r-installation-in-your-jobs) 
+ 1. [Download R source code](#1-download-r-source-code) 
+ 2. [Submit an interactive job to a build server](#2-submit-an-interactive-job-to-a-build-server) 
+ 3. [Compile base R from source code](#3-compile-base-r-from-source-code) 
+ 4. [Install additional R packages](#4-install-packages) 
+ 5. [Create a portable copy of your R installation that can be brought along with your jobs](#5-create-a-portable-copy-of-your-r-installation)
+ 6. [Use your custom R installation in your jobs](#6-use-your-custom-r-installation-in-your-jobs) 
 
 # Compile R
 

--- a/r-build.md
+++ b/r-build.md
@@ -11,7 +11,7 @@ for compiling versions of R that are currently not provided via the CHTC Squid W
 
 Before compiling R, please take a moment to review our [R Jobs](http://chtc.cs.wisc.edu/r-jobs.shtml) guide to see what versions of R are currently available on the HTC.
 
-**To best understand the below information, users 
+**To best understand the below information, you 
 should already have an understanding of how to:**
   * navigate within directories 
   * create/copy/move/delete files and directories 
@@ -174,4 +174,3 @@ server and should see a copy of your R tar archive:
 
 To use the R installation that was built using the steps in this guide, please follow 
 the steps and examples described on our [R Jobs](http://chtc.cs.wisc.edu/r-jobs.shtml) guide.
-

--- a/r-build.md
+++ b/r-build.md
@@ -12,12 +12,11 @@ for compiling versions of R that are currently not provided via the CHTC Squid W
 Before compiling R, please take a moment to review our [R Jobs](http://chtc.cs.wisc.edu/r-jobs.shtml) guide to see what versions of R are currently available on the HTC.
 
 **To best understand the below information, users 
-should already have an understanding of:**
-	* Using the command line to: 
-		* navigate within directories 
-		* create/copy/move/delete files and directories 
-		* how to run your intended program 
-	* Using HTCondor to submit jobs
+should already have an understanding of how to:**
+  * navigate within directories 
+  * create/copy/move/delete files and directories 
+  * run your intended program 
+  * use HTCondor to submit jobs
 
 This guide details the steps needed to: 
 
@@ -28,9 +27,7 @@ This guide details the steps needed to:
 
 # Compile R
 
-1. Download R Source Code
--------------------------
--------------------------
+## 1. Download R Source Code
 
 Before running any commands on CHTC, use a browser to get the source code 
 for your desired version of R from [CRAN](https://cran.r-project.org) 
@@ -38,9 +35,7 @@ Under "Source Code for all Platforms", find the R-#.#.#.tar.gz file for your
 desired version of R and download it to your computer before transferring a copy 
 to your `/home` directory on the submit server. 
 
-2. Submit An Interactive Job To A Build Server
-----------------------------------------------
-----------------------------------------------
+## 2. Submit An Interactive Job To A Build Server
 
 Creating an R installation can be computationally intensive and should not be 
 performed on the submit server. Instead, you will create your installation 
@@ -87,9 +82,7 @@ running the following command:
 The interactive build job should start in about a minute. Once it has
 started, the job has a time limit of four hours.
 
-3. Compile Base R From Source Code
-----------------------------------
-----------------------------------
+## 3. Compile Base R From Source Code
 
 Once the interactive job starts, R can be compiled. The general workflow will be 
 to first run the R configuration script followed by `make` and `make install`. 
@@ -130,18 +123,14 @@ If R has been installed successfully, you should be able to run the following co
 
 The output of the above command should match the version number that you want to be using!
 
-4. Install Packages 
--------------------
--------------------
+## 4. Install Packages 
 
 After your R compilations completed, if any additional R packages are required for your work, 
 please follow the steps in our [R Jobs](http://chtc.cs.wisc.edu/r-jobs.shtml) guide 
 starting with the `export` commands shown in step 1.B.1. After creating a compressed tar 
 archive of your `packages` directory return the the next steps in this guide.
 
-5. Create A Portable Copy of Your R Installation
-------------------------------------------------
-------------------------------------------------
+## 5. Create A Portable Copy of Your R Installation
 
 Once R has been successfully compiled (and after any packages have been installed), the final step 
 is to create a compressed tar archive of your R installation. From the top level directory:
@@ -177,9 +166,7 @@ server and should see a copy of your R tar archive:
 ```
 {.term}
 
-6. Use Your Custom R Installation In Your Jobs
-----------------------------------------------
-----------------------------------------------
+## 6. Use Your Custom R Installation In Your Jobs
 
 To use the R installation that was built using the steps in this guide, please follow 
 the steps and examples described on our [R Jobs](http://chtc.cs.wisc.edu/r-jobs.shtml) guide.

--- a/r-build.md
+++ b/r-build.md
@@ -20,10 +20,12 @@ should already have an understanding of how to:**
 
 This guide details the steps needed to: 
 
- 1. [Download R source code](#1.-Download-R-Source-Code) 
- 2. [Submit an interactive job to a build server](#2.-Submit-An-Interactive-Job-To-A-Build-Server)
- 3. Compile base R from source code
- 4. Create a portable copy of your R installation that can be brought along with your jobs
+ 1. [Download R source code](#1.-download-r-source-code) 
+ 2. [Submit an interactive job to a build server](#2.-submit-an-interactive-job-to-a-build-server) 
+ 3. [Compile base R from source code](#3.-compile-base-r-from-source-code) 
+ 4. [Install additional R packages](#4.-install-packages) 
+ 5. [Create a portable copy of your R installation that can be brought along with your jobs](#5.-create-a-portable-copy-of-your-r-installation)
+ 6. [Use your custom R installation in your jobs](#6.-use-your-custom-r-installation-in-your-jobs) 
 
 # Compile R
 
@@ -62,8 +64,8 @@ transfer_input_files = R-#.#.#.tar.gz
 +IsBuildJob = true
 requirements = (OpSysMajorVer =?= 7)
 request_cpus = 1
-request_memory = 2GB
-request_disk = 2GB
+request_memory = 4GB
+request_disk = 4GB
 
 queue
 ```
@@ -87,7 +89,7 @@ started, the job has a time limit of four hours.
 Once the interactive job starts, R can be compiled. The general workflow will be 
 to first run the R configuration script followed by `make` and `make install`. 
 
-To install R, first create a directory that will hold your R installation (e.g. R/) 
+To install R, first create a directory that will hold your R installation (e.g. `R/`) 
 , then extract all of the source code files from R-#.#.#.tar.gz and move into the source code directory:
 
 ``` 
@@ -121,13 +123,14 @@ If R has been installed successfully, you should be able to run the following co
 ```
 {.term}
 
-The output of the above command should match the version number that you want to be using!
+The output of the above command should match the version number that you just installed!
 
 ## 4. Install Packages 
 
-After your R compilations completed, if any additional R packages are required for your work, 
+After your R compilation has completed, if any additional R packages are required for your work, 
 please follow the steps in our [R Jobs](http://chtc.cs.wisc.edu/r-jobs.shtml) guide 
-starting with the `export` commands shown in step 1.B.1. After creating a compressed tar 
+starting with the `export` commands shown in step 
+[1.B.1](http://chtc.cs.wisc.edu/r-jobs.shtml#b.-install-the-packages). After creating a compressed tar 
 archive of your `packages` directory return the the next steps in this guide.
 
 ## 5. Create A Portable Copy of Your R Installation
@@ -146,8 +149,9 @@ is to create a compressed tar archive of your R installation. From the top level
 ```
 {.term}
 
-**If the size of `my_R#.#.#.tar.gz` is larger than ~100MB then your will need to use the CHTC
-Squid Wed Proxy to host this file** See our [Squid Web Proxy](http://chtc.cs.wisc.edu/file-avail-squid.shtml) guide for more details.
+**If the size of `my_R#.#.#.tar.gz` is larger than ~100MB then your will need to use 
+the CHTC Squid Wed Proxy to host this file.** See our 
+[Squid Web Proxy](http://chtc.cs.wisc.edu/file-avail-squid.shtml) guide for more details.
 
 Now you have a portable copy of your R installation that can be brought along with your jobs. 
 The final step is to terminate your interactive job, and HTCondor will tranfer your R tar archive 

--- a/r-build.md
+++ b/r-build.md
@@ -68,7 +68,7 @@ request_memory = 4GB
 request_disk = 4GB
 
 queue
-``` {:.sub}
+```
 
 Be sure to modify the above `transfer_input_files` statement with the appropriate 
 name of the R source code that you downloaded in the previous ste.

--- a/r-build.md
+++ b/r-build.md
@@ -9,7 +9,7 @@ title: Building R in HTC
 **This guide will provide instructions for compiling base R from source code and is intended 
 for compiling versions of R that are currently not provided via the CHTC Squid Web Proxy**
 
-Before compiling R, please take a moment to review our [R Jobs](/r-jobs.shtml) guide to see what versions of R are currently available on the HTC.
+Before compiling R, please take a moment to review our [R Jobs](/r-jobs.shtml) guide to see what versions of R are currently available.
 
 **To best understand the below information, you 
 should already have an understanding of how to:**
@@ -77,7 +77,7 @@ Once this submit file is created, you will start the interactive job by
 running the following command:
 
 ``` 
-[alice@submit]$ condor_submit -i build.sub
+[user@submit]$ condor_submit -i build.sub
 ```
 {:.term}
 
@@ -93,33 +93,35 @@ To install R, first create a directory that will hold your R installation (e.g. 
 , then extract all of the source code files from R-#.#.#.tar.gz and move into the source code directory:
 
 ``` 
-[alice@build]$ mkdir R/
-[alice@build]$ tar xzf R-#.#.#.tar.gz
-[alice@build]$ cd R-#.#.#/
+[user@build]$ mkdir R/
+[user@build]$ tar xzf R-#.#.#.tar.gz
+[user@build]$ cd R-#.#.#/
 ```
 {:.term}
 
 From the source code directory, run the following commands. **The `make` step may take a while to 
-complete!**: 
+complete!** If building R version 4.x.x or higher you will need to modify the below `configure` 
+command to include the flag `--with-pcre1` 
+(e.g. `./configure --prefix=$_CONDOR_SCRATCH_DIR/R --with-pcre1`).
 
 ```
-[alice@build]$ ./configure --prefix=$_CONDOR_SCRATCH_DIR/R
-[alice@build]$ make
-[alice@build]$ make install
+[user@build]$ ./configure --prefix=$_CONDOR_SCRATCH_DIR/R
+[user@build]$ make
+[user@build]$ make install
 ```
 {:.term}
 
 Then return the the top level directory:
 
 ```
-[alice@build]$ cd ../
+[user@build]$ cd ../
 ```
 {:.term}
 
 If R has been installed successfully, you should be able to run the following command as a test:
 
 ```
-[alice@build]$ R/bin/R --version
+[user@build]$ R/bin/R --version
 ```
 {:.term}
 
@@ -139,13 +141,13 @@ Once R has been successfully compiled (and after any packages have been installe
 is to create a compressed tar archive of your R installation. From the top level directory:
 
 ```
-[alice@build]$ tar czf my_R#.#.#.tar.gz R/
+[user@build]$ tar czf my_R#.#.#.tar.gz R/
 ```
 {:.term}
 
 **Be sure to check the size of your R tar archive:**
 ```
-[alice@build]$ ls -lh my_R#.#.#.tar.gz
+[user@build]$ ls -lh my_R#.#.#.tar.gz
 ```
 {:.term}
 
@@ -158,7 +160,7 @@ The final step is to terminate your interactive job, and HTCondor will tranfer y
 back to your `/home` directory:
 
 ```
-[alice@submit]$ exit
+[user@submit]$ exit
 ```
 {:.term}
 
@@ -166,7 +168,7 @@ Once your interactive job terminates, you will be back in your `/home` directory
 server and should see a copy of your R tar archive:
 
 ```
-[alice@submit]$ ls
+[user@submit]$ ls
 ```
 {:.term}
 

--- a/r-build.md
+++ b/r-build.md
@@ -1,0 +1,186 @@
+---
+highlighter: none
+layout: default
+title: Building R in HTC
+---
+
+#Overview
+
+**This guide will provide instructions for compiling base R from source code and is intended 
+for compiling versions of R that are currently not provided via the CHTC Squid Web Proxy**
+
+Before compiling R, please take a moment to review our [R Jobs](http://chtc.cs.wisc.edu/r-jobs.shtml) guide to see what versions of R are currently available on the HTC.
+
+**To best understand the below information, users 
+should already have an understanding of:**
+	* Using the command line to: 
+		* navigate within directories 
+		* create/copy/move/delete files and directories 
+		* how to run your intended program 
+	* Using HTCondor to submit jobs
+
+This guide details the steps needed to: 
+
+	1. Download R source code
+	2. Submit an interactive job to a build server 
+	3. Compile base R from source code
+	4. Create a portable copy of your R installation that can be brought along with your jobs
+
+# Compile R
+
+1. Download R Source Code
+-------------------------
+-------------------------
+
+Before running any commands on CHTC, use a browser to get the source code 
+for your desired version of R from [CRAN](https://cran.r-project.org) 
+Under "Source Code for all Platforms", find the R-#.#.#.tar.gz file for your 
+desired version of R and download it to your computer before transferring a copy 
+to your `/home` directory on the submit server. 
+
+2. Submit An Interactive Job To A Build Server
+----------------------------------------------
+----------------------------------------------
+
+Creating an R installation can be computationally intensive and should not be 
+performed on the submit server. Instead, you will create your installation 
+on a CHTC build server by using an interactive job. 
+
+The interactive job is essentially a job without an executable; 
+you will be the one running the commands, instead (in this case, to install R).
+Like a regular HTCondor job, once you finish your R installation on the build server, 
+the output files (your completed portable R installation) will be transferred back to 
+the submit server (so that you can use the R installation for later jobs). 
+
+To submit an interactive job, create a submit file called `build.sub` as shown below:
+
+``` {.sub}
+# build.sub
+# Software build file
+
+universe = vanilla
+log = interactive.log
+
+# change the name of the file to be the name of your source code
+transfer_input_files = R-#.#.#.tar.gz
+
++IsBuildJob = true
+requirements = (OpSysMajorVer =?= 7)
+request_cpus = 1
+request_memory = 2GB
+request_disk = 2GB
+
+queue
+```
+
+Be sure to modify the above `transfer_input_files` statement with the appropriate 
+name of the R source code that you downloaded in the previous ste.
+
+Once this submit file is created, you will start the interactive job by
+running the following command:
+
+``` 
+[alice@submit]$ condor_submit -i build.sub
+```
+{:.term}
+
+The interactive build job should start in about a minute. Once it has
+started, the job has a time limit of four hours.
+
+3. Compile Base R From Source Code
+----------------------------------
+----------------------------------
+
+Once the interactive job starts, R can be compiled. The general workflow will be 
+to first run the R configuration script followed by `make` and `make install`. 
+
+To install R, first create a directory that will hold your R installation (e.g. R/) 
+, then extract all of the source code files from R-#.#.#.tar.gz and move into the source code directory:
+
+``` 
+[alice@build]$ mkdir R/
+[alice@build]$ tar xzf R-#.#.#.tar.gz
+[alice@build]$ cd R-#.#.#/
+```
+{:.term}
+
+From the source code directory, run the following commands. **The `make` step may take a while to 
+complete!**: 
+
+```
+[alice@build]$ ./configure --prefix=$_CONDOR_SCRATCH_DIR/R
+[alice@build]$ make
+[alice@build]$ make install
+```
+{:.term}
+
+Then return the the top level directory:
+
+```
+[alice@build]$ cd ../
+```
+{.term}
+
+If R has been installed successfully, you should be able to run the following command as a test:
+
+```
+[alice@build]$ R/bin/R --version
+```
+{.term}
+
+The output of the above command should match the version number that you want to be using!
+
+4. Install Packages 
+-------------------
+-------------------
+
+After your R compilations completed, if any additional R packages are required for your work, 
+please follow the steps in our [R Jobs](http://chtc.cs.wisc.edu/r-jobs.shtml) guide 
+starting with the `export` commands shown in step 1.B.1. After creating a compressed tar 
+archive of your `packages` directory return the the next steps in this guide.
+
+5. Create A Portable Copy of Your R Installation
+------------------------------------------------
+------------------------------------------------
+
+Once R has been successfully compiled (and after any packages have been installed), the final step 
+is to create a compressed tar archive of your R installation. From the top level directory:
+
+```
+[alice@build]$ tar czf my_R#.#.#.tar.gz R/
+```
+{.term}
+
+**Be sure to check the size of your R tar archive:**
+```
+[alice@build]$ ls -lh my_R#.#.#.tar.gz
+```
+{.term}
+
+**If the size of `my\_R#.#.#.tar.gz` is larger than ~100MB then your will need to use the CHTC
+Squid Wed Proxy to host this file** See our [Squid Web Proxy](http://chtc.cs.wisc.edu/file-avail-squid.shtml) guide for more details.
+
+Now you have a portable copy of your R installation that can be brought along with your jobs. 
+The final step is to terminate your interactive job, and HTCondor will tranfer your R tar archive 
+back to your `/home` directory:
+
+```
+[alice@submit]$ exit
+```
+{.term}
+
+Once your interactive job terminates, you will be back in your `/home` directory on the submit 
+server and should see a copy of your R tar archive:
+
+```
+[alice@submit]$ ls
+```
+{.term}
+
+6. Use Your Custom R Installation In Your Jobs
+----------------------------------------------
+----------------------------------------------
+
+To use the R installation that was built using the steps in this guide, please follow 
+the steps and examples described on our [R Jobs](http://chtc.cs.wisc.edu/r-jobs.shtml) guide.
+

--- a/r-build.md
+++ b/r-build.md
@@ -4,7 +4,7 @@ layout: default
 title: Building R in HTC
 ---
 
-#Overview
+# Overview
 
 **This guide will provide instructions for compiling base R from source code and is intended 
 for compiling versions of R that are currently not provided via the CHTC Squid Web Proxy**
@@ -20,10 +20,10 @@ should already have an understanding of how to:**
 
 This guide details the steps needed to: 
 
-	1. Download R source code
-	2. Submit an interactive job to a build server 
-	3. Compile base R from source code
-	4. Create a portable copy of your R installation that can be brought along with your jobs
+ 1. [Download R source code](#1.-Download-R-Source-Code) 
+ 2. [Submit an interactive job to a build server](#2.-Submit-An-Interactive-Job-To-A-Build-Server)
+ 3. Compile base R from source code
+ 4. Create a portable copy of your R installation that can be brought along with your jobs
 
 # Compile R
 
@@ -146,7 +146,7 @@ is to create a compressed tar archive of your R installation. From the top level
 ```
 {.term}
 
-**If the size of `my\_R#.#.#.tar.gz` is larger than ~100MB then your will need to use the CHTC
+**If the size of `my_R#.#.#.tar.gz` is larger than ~100MB then your will need to use the CHTC
 Squid Wed Proxy to host this file** See our [Squid Web Proxy](http://chtc.cs.wisc.edu/file-avail-squid.shtml) guide for more details.
 
 Now you have a portable copy of your R installation that can be brought along with your jobs. 

--- a/r-jobs.md
+++ b/r-jobs.md
@@ -28,7 +28,7 @@ This guide details the steps needed to:
 
 If you want to build your own copy of base R, see this archived page:
 
--   [Building a R installation](archived/r-jobs.shtml)
+-   [Building a R installation](r-build.shtml)
 
 <a name="supported"></a>
 


### PR DESCRIPTION
# #29 
Create updated guide to build base R from source code for users that will run versions not currently provided in CHTC Squid Web Proxy. Includes updated link to this new guide from our "R Jobs" guide