### PR TITLE
Add link to help set CUDACapability requirement

### DIFF
--- a/gpu-jobs.md
+++ b/gpu-jobs.md
@@ -77,7 +77,8 @@ server, including:
 		<td>Represents various capabilities of the GPU. Can be used as a proxy for the GPU card type when 
 		requiring a specific type of GPU. More details on what the capability numbers mean can be found on the 
 		<a href="https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#compute-capabilities">
-		NVIDIA website</a>.</td>
+		NVIDIA website</a>. <a href="https://en.wikipedia.org/wiki/CUDA#GPUs_supported">Wikipedia</a> has
+		a table showing the CUDA compute capability for specific GPU architectures and cards.</td>
 	</tr>
 	<tr>
 		<td><code>CUDADriverVersion</code></td>

--- a/gpu-jobs.md
+++ b/gpu-jobs.md
@@ -75,10 +75,11 @@ server, including:
 	<tr>
 		<td><code>CUDACapability</code></td>
 		<td>Represents various capabilities of the GPU. Can be used as a proxy for the GPU card type when 
-		requiring a specific type of GPU. More details on what the capability numbers mean can be found on the 
+		requiring a specific type of GPU. <a href="https://en.wikipedia.org/wiki/CUDA#GPUs_supported">Wikipedia</a>
+		has a table showing the CUDA compute capability for specific GPU architectures and cards.
+		More details on what the capability numbers mean can be found on the 
 		<a href="https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#compute-capabilities">
-		NVIDIA website</a>. <a href="https://en.wikipedia.org/wiki/CUDA#GPUs_supported">Wikipedia</a> has
-		a table showing the CUDA compute capability for specific GPU architectures and cards.</td>
+		NVIDIA website</a>.</td>
 	</tr>
 	<tr>
 		<td><code>CUDADriverVersion</code></td>


### PR DESCRIPTION
This table contains the information that I find important when setting the `CUDACapability` requirement.  We could even consider removing the NVIDIA link, which is pretty technical.