### PR TITLE
Load secret key from local disk (if present)

### DIFF
--- a/cgi-chtc/get-started_captcha.php
+++ b/cgi-chtc/get-started_captcha.php
@@ -6,8 +6,15 @@ if(isset($_POST["captcha"])) {
   $recaptcha_response = $_POST["captcha"];
   unset($_POST["captcha"]);
   
-  $recaptcha_secret_key_path = "/p/condor/chtc-web/google-captcha/secret.key";
-  $recaptcha_secret_key = trim(file_get_contents($recaptcha_secret_key_path));
+  $recaptcha_secret_key_path = "/etc/keys/chtc-captcha.key";
+  $afs_recaptcha_secret_key_path = "/p/condor/chtc-web/google-captcha/secret.key";
+  $recaptcha_secret_key = "";
+  if(file_exists($recaptcha_secret_key_path)) {
+    $recaptcha_secret_key = trim(file_get_contents($recaptcha_secret_key_path));
+  }
+  if(! $recaptcha_secret_key) {  // doesn't exist or can't load - try it from AFS
+    $recaptcha_secret_key = trim(file_get_contents($afs_recaptcha_secret_key_path));
+  }
   $recaptcha_url = "https://www.google.com/recaptcha/api/siteverify";
 
   $recaptcha_post_data = array(


### PR DESCRIPTION
If the API key for the captcha is present on the local disk, use it. This allows the webserver to display the captcha without the credentials needed to read the file from AFS.