### PR TITLE
remove el7 from doc name, revise hpc-specific layout style

### DIFF
--- a/_includes/hpc-mainbody.shtml
+++ b/_includes/hpc-mainbody.shtml
@@ -1,0 +1,24 @@
+<!-- Top of Page Body -->
+<table BORDER="0" WIDTH="100%">
+<!-- <h1 align=left valign=center>The Center for High Throughput Computing</h1> -->
+
+<div id="osg_power"> <span style="height: 30px">Powered by:</span><br /><a href="http://opensciencegrid.org"><img alt="Open Science Grid" src="/images/Open_Science_Grid_Consortium(Logo).jpg" width="123" height="70" /></a></div>
+
+<div id="hours"> <span style="height: 30px">
+	<a href="https://twitter.com/CHTC_UW" style="color:white;"><center><img alt="Twitter" src="/images/twitter.png" width="50" height="50"></center></a> 
+	<center><a href="https://github.com/CHTC/chtc-website-source" style="color:white;"><img alt="GitHub" src="/images/GitHub_Logo_White.png" width="92" height="38"></center></a></span></div>
+
+<div id="hours"> <span style="height: 35px">
+<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+<a href="http://chtc.cs.wisc.edu/get-help.shtml" style="color:white;">
+<center><b>Office Hours!</b>
+<p style="margin-bottom: 1px;"></p>
+Tues/Thurs, 3-5pm
+Click for details
+</center></a></span>
+<p style="margin-bottom: 1px;"></p>
+<center><a href="http://chtc.cs.wisc.edu/sign-in.shtml" style="color:white;">Sign-In Here</a></center>
+</div>
+	
+<div style="margin-top:1em;"><a href="http://chtc.cs.wisc.edu/"><img alt="Center for High Throughput Computing" src="/images/CHTC-logo.png" width="500" height="90"></a></div>
+

--- a/_includes/template-hpc-guide-links.shtml
+++ b/_includes/template-hpc-guide-links.shtml
@@ -1,9 +1,10 @@
 <link rel="stylesheet" type="text/css" href="/bootstrap.css" />
 
 <h1>Disclaimer:</hr>
-<p style="background-color:yellow;">This guide pertains to the new configuration of the HPC 
-cluster which will be available starting **Thursday, September 17**. For instructions on the currently 
-operating cluster, please see our previous <a href="HPCuseguide.shtml">HPC Basic Use Guide</a></p>
+<p style="background-color:yellow;">This guide is a working draft (i.e. still in progress) 
+that pertains to the new configuration of the HPC cluster which will be available starting 
+**Thursday, September 17, 2020**. For instructions on the currently operating cluster, please see our 
+previous <a href="HPCuseguide.shtml">HPC Basic Use Guide</a></p>
 <hr>
 <h1>Additional HPC Guides</h1>
 <br>

--- a/_includes/template-hpc-guide-links.shtml
+++ b/_includes/template-hpc-guide-links.shtml
@@ -1,8 +1,18 @@
 <link rel="stylesheet" type="text/css" href="/bootstrap.css" />
 
+<h1>Disclaimer:</hr>
+<p style="background-color:yellow;">This guide pertains to the new configuration of the HPC 
+cluster which will be available starting **Thursday, September 17**. For instructions on the currently 
+operating cluster, please see our previous <a href="HPCuseguide.shtml">HPC Basic Use Guide</a></p>
+<hr>
+<h1>Additional HPC Guides</h1>
+<br>
 <div class="card-deck">
 	<div class="card border-secondary h-100 text-center">  
-		<a href="hpc-overview-el7.shtml"><li class="list-group-item list-group-item-action list-group-item-dark h-100" style="width: auto; height: auto !important;">HPC Overview</li></a>
+		<a href="connecting.shtml"><li class="list-group-item list-group-item-action list-group-item-dark h-100" style="width: auto; height: auto !important;">Connecting to CHTC</li></a>
+	</div>
+	<div class="card border-secondary h-100 text-center">  
+		<a href="hpc-overview.shtml"><li class="list-group-item list-group-item-action list-group-item-dark h-100" style="width: auto; height: auto !important;">HPC Overview</li></a>
 	</div>
 	<div class="card border-secondary h-100 text-center">  
 		<a href="hpc-job-submission.shtml"><li class="list-group-item list-group-item-action list-group-item-dark h-100" style="width: auto; height: auto !important;">HPC Job Submission</li></a>
@@ -10,7 +20,6 @@
 	<div class="card border-secondary h-100 text-center">  
 		<a href="hpc-software.shtml"><li class="list-group-item list-group-item-action list-group-item-dark h-100" style="width: auto; height: auto !important;">HPC Software</li></a>
 	</div>
-	<div class="card border-secondary h-100 text-center">  
-		<a href="guides.shtml"><li class="list-group-item list-group-item-action list-group-item-dark h-100" style="width: auto; height: auto !important;">Place Holder</li></a>
-	</div>
 </div>
+<hr>
+<h1>{{ page.title }}</h1>

--- a/_layouts/hpc_layout.html
+++ b/_layouts/hpc_layout.html
@@ -2,7 +2,7 @@
 {% include template-1-openhead.shtml %}
 {% include template-2-opensidebar.shtml %}
 {% include template-3-sidebar.shtml %}
-{% include template-4-mainbody.shtml %}
+{% include hpc-mainbody.shtml %}
 {% include template-hpc-guide-links.shtml %}
 
 {{ content }}

--- a/guides.md
+++ b/guides.md
@@ -146,19 +146,28 @@ through the process of creating your own large-scale job submission, step-by-ste
 through the process of using the cluster, step-by-step.</p> -->
 
 <h2>Guides by Topic</h2>
-
-
-<br>
-<div class="card border-secondary" style="width: 31.5%;" >    
-	<img alt="Card image cap" class="card-img-top img-responsive" src="guide-icons/servers.png" style="margin-left: auto;margin-right: auto;width: 30%;"/>
-	<h5 class="card-title text-center">All Cluster Guides</h5>
-	<ul class="list-group list-group-flush" style="height: auto !important;">
-		<a href="/connecting.shtml"><li class="list-group-item list-group-item-action list-group-item-dark h-100" style="width: auto; height: auto !important; border-radius: 1px;">Connecting to CHTC</li></a>
-		<a href="/HPCuseguide.shtml"><li class="list-group-item list-group-item-action list-group-item-dark h-100" style="width: auto; height: auto !important; border-radius: 1px;">HPC Cluster Basic Use Guide</li></a>
-		<a href="/MPIuseguide.shtml"><li class="list-group-item list-group-item-action list-group-item-dark h-100" style="width: auto; height: auto !important;">MPI Use Guide</li></a>
-	</ul>
-</div>	
-
+<div class="card-deck">
+	<div class="card border-secondary h-100" >    
+		 <img alt="Card image cap" class="card-img-top img-responsive" src="guide-icons/servers.png" style="margin-left: auto;margin-right: auto;width: 30%;"/>
+		<h5 class="card-title text-center">HPC Cluster Guides</h5>
+		<ul class="list-group list-group-flush" style="height: auto !important;">
+			<a href="/connecting.shtml"><li class="list-group-item list-group-item-action list-group-item-dark h-100" style="width: auto; height: auto !important; border-radius: 1px;">Connecting to CHTC</li></a>
+			<a href="/HPCuseguide.shtml"><li class="list-group-item list-group-item-action list-group-item-dark h-100" style="width: auto; height: auto !important; border-radius: 1px;">HPC Cluster Basic Use Guide</li></a>
+			<a href="/MPIuseguide.shtml"><li class="list-group-item list-group-item-action list-group-item-dark h-100" style="width: auto; height: auto !important;">MPI Use Guide</li></a>
+		</ul>
+	</div>
+			
+	<div class="card border-secondary h-100" >    
+		 <img alt="Card image cap" class="card-img-top img-responsive" src="guide-icons/servers.png" style="margin-left: auto;margin-right: auto;width: 30%;"/>
+		<h5 class="card-title text-center">New Upgraded HPC Guides</h5>
+		<ul class="list-group list-group-flush" style="height: auto !important;">
+			<a href="/connecting.shtml"><li class="list-group-item list-group-item-action list-group-item-dark h-100" style="width: auto; height: auto !important; border-radius: 1px;">Connecting to CHTC</li></a>
+			<a href="/hpc-overview.shtml"><li class="list-group-item list-group-item-action list-group-item-dark h-100" style="width: auto; height: auto !important; border-radius: 1px;">HPC Cluster Overview Guide</li></a>
+			<a href="/hpc-software.shtml"><li class="list-group-item list-group-item-action list-group-item-dark h-100" style="width: auto; height: auto !important;">HPC Software</li></a>
+			<a href="/hpc-job-submission.shtml"><li class="list-group-item list-group-item-action list-group-item-dark h-100" style="width: auto; height: auto !important;">HPC Job Submission</li></a>
+		</ul>
+	</div>
+</div>
 
 <hr>
 <a name="ext"></a>

--- a/guides.md
+++ b/guides.md
@@ -159,7 +159,7 @@ through the process of using the cluster, step-by-step.</p> -->
 			
 	<div class="card border-secondary h-100" >    
 		 <img alt="Card image cap" class="card-img-top img-responsive" src="guide-icons/servers.png" style="margin-left: auto;margin-right: auto;width: 30%;"/>
-		<h5 class="card-title text-center">New Upgraded HPC Guides</h5>
+		<h5 class="card-title text-center">New HPC Configuration Guides (Sept 17)</h5>
 		<ul class="list-group list-group-flush" style="height: auto !important;">
 			<a href="/connecting.shtml"><li class="list-group-item list-group-item-action list-group-item-dark h-100" style="width: auto; height: auto !important; border-radius: 1px;">Connecting to CHTC</li></a>
 			<a href="/hpc-overview.shtml"><li class="list-group-item list-group-item-action list-group-item-dark h-100" style="width: auto; height: auto !important; border-radius: 1px;">HPC Cluster Overview Guide</li></a>
@@ -186,4 +186,3 @@ through the process of using the cluster, step-by-step.</p> -->
 
 <hr>
 <a href="/icon_credits.shtml">Icon Credits</a>
-

--- a/hpc-job-submission.md
+++ b/hpc-job-submission.md
@@ -31,7 +31,7 @@ called a "batch" file. The top half of the file consists of `#SBATCH`
 options which communicate needs or parameters of the job -- these lines 
 are **not** comments, but essential options for the job. The values for 
 `#SBATCH` options should reflect the size of nodes and run time limits 
-described [here](/hpc-overview-el7)
+described [here](/hpc-overview)
 
 After the `#SBATCH` options, the submit file should contain the commands
 needed to run your job, including loading any needed software modules. 

--- a/hpc-job-submission.md
+++ b/hpc-job-submission.md
@@ -31,7 +31,7 @@ called a "batch" file. The top half of the file consists of `#SBATCH`
 options which communicate needs or parameters of the job -- these lines 
 are **not** comments, but essential options for the job. The values for 
 `#SBATCH` options should reflect the size of nodes and run time limits 
-described [here](/hpc-overview)
+described [here](/hpc-overview).
 
 After the `#SBATCH` options, the submit file should contain the commands
 needed to run your job, including loading any needed software modules. 

--- a/hpc-overview.md
+++ b/hpc-overview.md
@@ -103,8 +103,8 @@ of researcher owned hardware and which all HPC users can access on a
 backfill capacity via the `pre` partition (more details below).
 
 ### Partitions
-
-{:.gtable}
+   
+  {:.gtable}
   | Partition | p-name | \# nodes (N) | t-max | t-default | max nodes/job | cores/node (n) | RAM/node (GB) |
   | --- |
   | University | univ | 38 | 7 days | 1 day | 16 | 16 | 64


### PR DESCRIPTION
1. removed "el7" from overview guide name and revised links accordingly
2. modified hpc-specific layout page design also now includes Christina's disclaimer message (with yellow background for font to standout)
3. add box to All User Guides page with links to new HPC guides