### PR TITLE
Update GPU Lab mailing list signup instructions

### DIFF
--- a/gpu-lab.md
+++ b/gpu-lab.md
@@ -41,7 +41,8 @@ If you want to use GPU resources in CHTC for your research:
 The CHTC GPU Lab mailing list is used to announce new GPU hardware availability and 
 GPU-related events, solicit feedback from GPU users, and share best practices for 
 GPU computing in CHTC. Any CHTC user can subscribe to the list by 
-emailing [join-chtc-gpu-lab@lists.wisc.edu](mailto:join-chtc-gpu-lab@lists.wisc.edu).
+emailing [chtc-gpu-lab+subscribe@g-groups.wisc.edu](mailto:chtc-gpu-lab+subscribe@g-groups.wisc.edu)
+and clicking the Join This Group button in the automated response message.
 Their subscription request will be reviewed by the list administrators.
 
 > The CHTC GPU Lab is led by Anthony Gitter, Lauren Michael, Brian Bockelman, and Miron Livny.

--- a/gpu-lab.md
+++ b/gpu-lab.md
@@ -41,8 +41,8 @@ If you want to use GPU resources in CHTC for your research:
 The CHTC GPU Lab mailing list is used to announce new GPU hardware availability and 
 GPU-related events, solicit feedback from GPU users, and share best practices for 
 GPU computing in CHTC. Any CHTC user can subscribe to the list by 
-emailing [chtc-gpu-lab+subscribe@g-groups.wisc.edu](mailto:chtc-gpu-lab+subscribe@g-groups.wisc.edu)
-and clicking the Join This Group button in the automated response message.
+emailing [chtc-gpu-lab+managers@g-groups.wisc.edu](mailto:chtc-gpu-lab+managers@g-groups.wisc.edu)
+and asking to join.
 Their subscription request will be reviewed by the list administrators.
 
 > The CHTC GPU Lab is led by Anthony Gitter, Lauren Michael, Brian Bockelman, and Miron Livny.


### PR DESCRIPTION
The GPU Lab mailing list has migrated to Google Groups.  Signup is now more complicated, and these instructions over-simplify the process.  My testing suggests that the instructions here require a UW-Madison G Suite account or a Google Account.  The button won't work if the user isn't signed in to Google.

Do we want to expand the instructions?  I can still manually add users, so an alternative option is to ask new users to email me.