### PR TITLE
fix terminal sytle rendering

### DIFF
--- a/file-avail-largedata.md
+++ b/file-avail-largedata.md
@@ -301,7 +301,7 @@ items are present in a directory:
 ```
 [username@transfer ~]$ get_quotas /staging/username
 ```
-{.term}
+{:.term}
 
 Alternatively, the `ncdu` command can also be used to see how many 
 files and directories are contained in a given path:

--- a/hpc-overview.md
+++ b/hpc-overview.md
@@ -214,7 +214,7 @@ items are present in a directory:
 ```
 [username@hpclogin1 ~]$ get_quotas /home/username /software/username
 ```
-{.term}
+{:.term}
 
 Alternatively, the `ncdu` command can also be used to see how many 
 files and directories are contained in a given path:


### PR DESCRIPTION
terminal style rendering was broken due to using {.term} instead of {:.term}