### PR TITLE
Consistently state HPC int partition t-max is 1 hr

### DIFF
--- a/hpc-job-submission.md
+++ b/hpc-job-submission.md
@@ -104,7 +104,7 @@ a job as described above, you can request an interactive job on the cluster.
 There is a dedicated partition 
 for interactive work called `int`; you may request up to a full node (16 CPUs, 
 64 GB RAM) when requesting an interactive session in the \"int\" partition and 
-the session is limited to 30 minutes. Using another partition (like `pre`) will 
+the session is limited to 60 minutes. Using another partition (like `pre`) will 
 mean your interactive job is subject to the limits of that partition. 
 
 The command to request an interactive job is `srun`, and includes the partition

--- a/hpc-overview.md
+++ b/hpc-overview.md
@@ -124,7 +124,7 @@ backfill capacity via the `pre` partition (more details below).
   | Partition | p-name | \# nodes (N) | t-max | t-default | max nodes/job | cores/node (n) | RAM/node (GB) |
   | --- |
   | University 2 | univ2 | 148 | 7 days | 1 day | 16 | 20 | 128
-  | Interactive | int | 6 | 1 hr | 1hr | 1 | 20 | 128
+  | Interactive | int | 6 | 1 hr | 1 hr | 1 | 20 | 128
   | Pre-emptable (backfill) | pre | 316 | 24 hrs | 4 hrs | 16 | 20 | 128
   | Owners | *unique* | 124 | 7 days | 24 hrs | *unique* | 20 | 128
   | Astronomy Dept (differs) | astro3 | 24 | *4 days* | 24 hrs | 16 | 20 | 128


### PR DESCRIPTION
Per @jmvera255 `int` was changed to a `t-max` of 1 hr in the EL7 transition.