### PR TITLE
Added a Development Page

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -1,9 +1,9 @@
 name: Deploy Production Site
 on:
   push:
-    branches: [master]
+    branches: [production]
   pull_request:
-    branches: [master]
+    branches: [production]
 jobs:
   build-and-maybe-deploy:
     runs-on: ubuntu-18.04

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -1,4 +1,4 @@
-name: Build/deploy web pages
+name: Deploy Production Site
 on:
   push:
     branches: [master]
@@ -26,6 +26,7 @@ jobs:
         env:
           #NO_PUSH: 1
           TARGET_REPO: CHTC/chtc.github.io
+          BRANCH: master
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         if: ${{ github.event_name != 'pull_request' && github.repository_owner == 'CHTC' }}
         name: Deploy web pages on merge/push

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -1,9 +1,11 @@
 name: Deploy Production Site
 on:
   push:
-    branches: [production]
+    branches: [master]
   pull_request:
-    branches: [production]
+    branches: [master]
+  schedule:
+    - cron: '0 0 * * *'
 jobs:
   build-and-maybe-deploy:
     runs-on: ubuntu-18.04

--- a/.github/workflows/web-preview.yml
+++ b/.github/workflows/web-preview.yml
@@ -1,10 +1,10 @@
-
-name: Deploy preview web area
+name: Deploy Development Site
 
 on:
   push:
-    branches: [preview]
-
+    branches: [production]
+  pull_request:
+    branches: [production]
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest
@@ -18,7 +18,6 @@ jobs:
           ruby-version: 2.6
           bundler-cache: true
       - run: |
-          sed -i "s|baseurl: ''|baseurl: '/web-preview'|" _config.yml
           ./script/cibuild
         name: Build web pages
       # SSH key recipe from https://www.webfactory.de/blog/use-ssh-key-for-private-repositories-in-github-actions
@@ -26,12 +25,12 @@ jobs:
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts
           ssh-agent -a "$SSH_AUTH_SOCK" > /dev/null
-          ssh-add - <<< "${{ secrets.PREVIEW_DEPLOY_KEY }}"
+          ssh-add - <<< "${{ secrets.DEPLOY_KEY }}"
           ./script/cideploy
         env:
           #NO_PUSH: 1
-          TARGET_REPO: CHTC/web-preview
-          BRANCH: main
+          TARGET_REPO: CHTC/chtc.github.io
+          BRANCH: development
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         if: ${{ github.event_name != 'pull_request' && github.repository_owner == 'CHTC' }}
-        name: Deploy preview web pages on merge/push
+        name: Deploy web pages on merge/push

--- a/.github/workflows/web-preview.yml
+++ b/.github/workflows/web-preview.yml
@@ -2,9 +2,9 @@ name: Deploy Development Site
 
 on:
   push:
-    branches: [master]
+    branches: [preview]
   pull_request:
-    branches: [master]
+    branches: [preview]
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest
@@ -25,12 +25,12 @@ jobs:
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts
           ssh-agent -a "$SSH_AUTH_SOCK" > /dev/null
-          ssh-add - <<< "${{ secrets.DEPLOY_KEY }}"
+          ssh-add - <<< "${{ secrets.PREVIEW_DEPLOY_KEY }}"
           ./script/cideploy
         env:
           #NO_PUSH: 1
-          TARGET_REPO: CHTC/chtc.github.io
-          BRANCH: development
+          TARGET_REPO: CHTC/web-preview
+          BRANCH: main
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         if: ${{ github.event_name != 'pull_request' && github.repository_owner == 'CHTC' }}
-        name: Deploy web pages on merge/push
+        name: Deploy preview web pages on merge/push

--- a/.github/workflows/web-preview.yml
+++ b/.github/workflows/web-preview.yml
@@ -2,9 +2,9 @@ name: Deploy Development Site
 
 on:
   push:
-    branches: [production]
+    branches: [master]
   pull_request:
-    branches: [production]
+    branches: [master]
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -111,3 +111,20 @@ can install and use the `pandoc` converter:
 You'll still want to go through and double check / clean up the text, but that's a good starting point. Once the 
 document is converted from markdown to html, the file extension should be `.md` instead. If you use the 
 command above, this means you can just delete the `.shtml` version of the file and commit the new `.md` one. 
+
+
+# Making Website Changes
+
+This repository uses [GitHub Actions](https://github.com/CHTC/chtc-website-source/tree/master/.github/workflows)
+to deploy a website preview from the `master` branch to the [web-preview repository](https://chtc.github.io/).
+The [production website](https://chtc.cs.wisc.edu/) is built automatically by GitHub Pages from the `production` branch.
+
+To make changes to the website, use the following workflow:
+
+1.  Submit a pull request with website updates to the `master` branch (the default) and request a review
+2.  Upon approval and merge of the pull request, changes can be previewed at [https://chtc.github.io/](https://chtc.github.io/).
+3.  If additional changes are necessary, repeat steps 1 and 2.
+4.  When satisfied with the preview website, submit a
+	[pull request](https://github.com/CHTC/chtc-website-source/compare/production...master)
+	from `production` to `master`
+5.  After the pull request from step 4 has been merged, verify the changes at [https://chtc.cs.wisc.edu/](https://chtc.cs.wisc.edu/)


### PR DESCRIPTION
 Designated a development page to be served from [https://chtc.github.io/](https://chtc.github.io/).

This updates the workflow so that the steps are now:
1. Push new feature to the master branch so they can be viewed on the dev page. 
2. Check the updates are what was intended
3. Merge master into production which will move the site to [https://chtc.cs.wisc.edu/](https://chtc.cs.wisc.edu/).

**When this is ready to go live we will need to make the branch that the Github page is served from the development branch on [CHTC/chtc.github.io](https://github.com/CHTC/chtc.github.io)**