### PR TITLE
Fix path in Julia guide

### DIFF
--- a/julia-jobs.md
+++ b/julia-jobs.md
@@ -40,7 +40,7 @@ with base Julia and Standard Library.
 	tar -xzf julia-#.#.#-linux-x86_64.tar.gz
 
 	# add Julia binary to PATH
-	export PATH=$_CONDOR_SCRATCH_DIR/julia-#-#-#/bin:$PATH
+	export PATH=$_CONDOR_SCRATCH_DIR/julia-#.#.#/bin:$PATH
 
 	# run Julia script
 	julia my-script.jl
@@ -219,7 +219,7 @@ the Julia Standard library) use the example script directly below.
 tar -xzf julia-#.#.#-linux-x86_64.tar.gz
 
 # add Julia binary to PATH
-export PATH=$_CONDOR_SCRATCH_DIR/julia-#-#-#/bin:$PATH
+export PATH=$_CONDOR_SCRATCH_DIR/julia-#.#.#/bin:$PATH
 
 # run Julia script
 julia my-script.jl
@@ -238,7 +238,7 @@ tar -xzf julia-#.#.#-linux-x86_64.tar.gz
 tar -xzf my-project.tar.gz
 
 # add Julia binary to PATH
-export PATH=$_CONDOR_SCRATCH_DIR/julia-#-#-#/bin:$PATH
+export PATH=$_CONDOR_SCRATCH_DIR/julia-#.#.#/bin:$PATH
 # add Julia packages to DEPOT variable
 export JULIA_DEPOT_PATH=$_CONDOR_SCRATCH_DIR/my-project
 


### PR DESCRIPTION
As discovered by one of our users (see ticket 103630),
Julia (at least as of version 1.6.1) extracts to a directory
named julia-#.#.#, not julia-#-#-#.