### PR TITLE
correcting link to template subfile

### DIFF
--- a/uw-research-computing/helloworld.md
+++ b/uw-research-computing/helloworld.md
@@ -87,7 +87,7 @@ queue 3
 {:.sub}
 
 > For a \"template\" version of this submit file without the comments,
-> [click here](files/template.sub).
+> [click here](../files/template.sub).
 
 **2.** Now, create the executable that we specified above: copy the text
 below and paste it into a file called `hello-chtc.sh`


### PR DESCRIPTION
unless we'd rather move the file itself and have a `files/` subdirectory in the `uw-research-computing` folder?