### PR TITLE
Add NoIndex Meta tag to Preview Pages

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,6 +15,12 @@
         iframe.width = (newwidth) + "px";
     }
 </script>
+{% if jekyll.environment == 'production' %}
+
+{% else %}
+<meta name="robots" content="noindex">
+{% endif %}
+
 {% if site.google_analytics and jekyll.environment == 'production' %}
 {% include analytics.html %}
 {% endif %}


### PR DESCRIPTION
We don't want our preview pages splitting SEO with the main site