### PR TITLE
Add staff scheduling

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -17,6 +17,10 @@ jobs:
           ./script/cibuild production
         name: Build web pages
       # SSH key recipe from https://www.webfactory.de/blog/use-ssh-key-for-private-repositories-in-github-actions
+      - name: Add the schedule file symlink
+        run: |
+          cd _site/staff
+          ln -s /p/condor/public/html/developers/schedules schedules
       - run: |
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ vendor/
 .idea/
 .vscode/
 .vagrant/
+
+# The staff/schedules symlink is created by the GHA build_deploy.yml
+/staff/schedules

--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ exclude: [vendor, deploy_key.enc, TEMPLATE.shtml, archive_html, dev_website]
 google_analytics:
 
 # Jekyll does not build hidden directories by default.
-include: [".well-known", ".htaccess"]
+include: [".well-known", ".htaccess", ".gitignore"]
 
 markdown_ext : "md,shtml"
 

--- a/script/rsync_include_list
+++ b/script/rsync_include_list
@@ -1,1 +1,2 @@
 .htaccess
+.gitignore

--- a/staff/.htaccess
+++ b/staff/.htaccess
@@ -1,0 +1,12 @@
+AuthUserFile /p/condor/public/developers/dev-webpage-passwd
+AuthName "Condor Developers"
+AuthType Basic
+<Limit GET>
+require valid-user
+</Limit>
+
+#AddHandler perl-script .html
+#PerlHandler HTML::Mason::ApacheHandler
+#PerlSetVar MasonCompRoot /s/www/html/condor/developers
+#PerlSetVar MasonDataDir /p/condor/public/mason
+#DefaultType text/html


### PR DESCRIPTION
Tested in the CHTC folder on AFS so I am quite confident it works.

Using the symlink in Git was @jasoncpatton's idea.

To create the symlink I did the commands below at website root.

```
mkdir staff
ln -s /p/condor/public/html/developers/schedules staff/schedules
```

The .htaccess file is the same from /p/condor/public/html/developers/.htaccess.
