### PR TITLE
Use Reply-To instead of spoofing email addresses

### DIFF
--- a/cgi-chtc/get-started_captcha.php
+++ b/cgi-chtc/get-started_captcha.php
@@ -55,7 +55,8 @@ if(isset($_POST["captcha"])) {
   if($recaptcha_success === True) { // User passed captcha
     //$fd = popen("mail -s 'CHTC Engagement Request' chtc@cs.wisc.edu -- -f$safe_email", "w");
     //$fd = popen("mail -s 'CHTC Engagement Request' chtc@cs.wisc.edu", "w");
-    $fd = popen("mailx -s 'CHTC Engagement Request' -r $safe_email chtc@cs.wisc.edu", "w");
+    //$fd = popen("mailx -s 'CHTC Engagement Request' -r $safe_email chtc@cs.wisc.edu", "w");
+    $fd = popen("mailx -s 'CHTC Engagement Request' -a 'Reply-To: $safe_email' chtc@cs.wisc.edu", "w");
     fputs($fd, $messg);
     $e = pclose($fd);
 


### PR DESCRIPTION
At some point recently, the mailservers responsible for getting
mail from our webserver to our ticketing system started being
particular about checking for spoofed From addresses. So two
changes are made to how the emails are now constructed:

1. They are "From" whatever address mailx is set to use by default
(www-data@local-hostname.whatever), which the mailservers are
happy with since it's not a spoofed address
2. They have a "Reply-To" address matching the preferred email
given in the form, which the ticketing system is happy to use
as the Requestor field.