### PR TITLE
Add facilitator images

### DIFF
--- a/_data/team.yml
+++ b/_data/team.yml
@@ -7,17 +7,19 @@
   description: "Livny is a Professor of Computer Science and the lead of the PATh project."
 - name: "Lauren Michael"
   status: Leadership
-  image: "images/team/lauren-michael.png"
+  image: "/images/team/lauren-michael.png"
   job_title: "Lead Research Computing Facilitator"
   website: "https://wid.wisc.edu/people/lauren-michael/"
   institution: "University of Wisconsin–Madison"
   description: "Michael is a Research Computing Facilitator at UW-Madison and co-lead of the FoCaS area."
+  is_facilitator: 1
 - name: "Christina Koch"
   status: Staff
-  image: "images/team/christina-koch.jpg"
+  image: "/images/team/christina-koch.jpg"
   job_title: "Research Computing Facilitator"
   institution: "University of Wisconsin - Madison"
   website: "https://wid.wisc.edu/people/christina-koch/"
+  is_facilitator: 1
 - name: "Brian Bockelman"
   status: Leadership
   image: "images/team/brian-bockelman.jpeg"
@@ -143,9 +145,10 @@
   website:
 - name: "Rachel Lombardi"
   status: Staff
-  image: "images/team/rachel-lombardi.jpg"
+  image: "/images/team/rachel-lombardi.jpg"
   job_title: "Research Computing Facilitator"
   institution: "University of Wisconsin–Madison"
+  is_facilitator: 1
   website:
 - name: "Tim Slauson"
   status: Staff

--- a/uw-research-computing/get-help.md
+++ b/uw-research-computing/get-help.md
@@ -8,6 +8,19 @@ title: Get Help!
 
 ## Research Computing Facilitators
 
+<div class="row justify-content-around d-none d-sm-flex">
+    {% assign facilitators = site.data.team | where: "is_facilitator", "1" %}
+    {% for facilitator in facilitators %}
+        <div class="col-auto">
+            <figure class="p-3">
+                <img style="object-fit: cover; border-radius: 50%; width: 10rem; height: 10rem" class="" src="{{ facilitator.image | relative.url}}" alt="{{ facilitator.name}}'s Headshot">
+                <figcaption>{{ facilitator.name }}</figcaption>
+            </figure>
+        </div>
+    {% endfor %}
+</div>
+
+
 To help researchers effectively utilize computing resources, our Research
 Computing Facilitators (RCFs) not only assist your in
 implementing your computational work on CHTC compute resources

--- a/uw-research-computing/get-help.md
+++ b/uw-research-computing/get-help.md
@@ -14,7 +14,7 @@ title: Get Help!
         <div class="col-auto">
             <figure class="p-3">
                 <img style="object-fit: cover; border-radius: 50%; width: 12rem; height: 12rem" class="" src="{{ facilitator.image | relative.url}}" alt="{{ facilitator.name}}'s Headshot">
-                <figcaption>{{ facilitator.name }}</figcaption>
+                <figcaption class="mt-1"><b>{{ facilitator.name }}</b><br>{{facilitator.job_title}}</figcaption>
             </figure>
         </div>
     {% endfor %}

--- a/uw-research-computing/get-help.md
+++ b/uw-research-computing/get-help.md
@@ -13,7 +13,7 @@ title: Get Help!
     {% for facilitator in facilitators %}
         <div class="col-auto">
             <figure class="p-3">
-                <img style="object-fit: cover; border-radius: 50%; width: 10rem; height: 10rem" class="" src="{{ facilitator.image | relative.url}}" alt="{{ facilitator.name}}'s Headshot">
+                <img style="object-fit: cover; border-radius: 50%; width: 12rem; height: 12rem" class="" src="{{ facilitator.image | relative.url}}" alt="{{ facilitator.name}}'s Headshot">
                 <figcaption>{{ facilitator.name }}</figcaption>
             </figure>
         </div>


### PR DESCRIPTION
I made the images a bit larger then this. Information is populated from the team file, but if the # of facilitators change the image size will have to be tweaked. 

<img width="1126" alt="Screen Shot 2022-01-25 at 3 46 46 PM" src="https://user-images.githubusercontent.com/49032265/151065542-c38d754e-7c1e-4c8a-ba46-feeef4c4465a.png">
