### PR TITLE
Add IceCube SciTokens issuer

### DIFF
--- a/icecube/.well-known/issuer.jwks
+++ b/icecube/.well-known/issuer.jwks
@@ -1,0 +1,13 @@
+{
+    "keys": [
+        {
+            "alg": "ES256",
+            "crv": "P-256",
+            "kid": "dad0",
+            "kty": "EC",
+            "use": "sig",
+            "x": "VT3b6ftX9JgdB_9rXn4QOYjyh3K3y6bN2ANjlDJfcWA=",
+            "y": "Hgyz6Ao2xn0xr6CSAltGw1jGVvfUXNQI5R6FherIGIg="
+        }
+    ]
+}

--- a/icecube/.well-known/openid-configuration
+++ b/icecube/.well-known/openid-configuration
@@ -1,0 +1,4 @@
+{  
+   "issuer":"https://chtc.cs.wisc.edu/icecube",
+   "jwks_uri":"https://chtc.cs.wisc.edu/icecube/.well-known/issuer.jwks"
+}


### PR DESCRIPTION
Adding the public key for the IceCube GWMS Frontend SciTokens at the requested issuer URL. See: https://opensciencegrid.atlassian.net/browse/OPS-275

@CannonLock does adding a new, empty (except for a hidden directory) directory cause any problems?