### PR TITLE
Add requirements line to run on CentOS Stream 8

### DIFF
--- a/uw-research-computing/helloworld.md
+++ b/uw-research-computing/helloworld.md
@@ -75,6 +75,11 @@ should_transfer_files = YES
 when_to_transfer_output = ON_EXIT
 # transfer_input_files = file1,/absolute/pathto/file2,etc
 #
+# Add a requirements line to require jobs to run on a machine running 
+# CentOS Stream 8, which will become the default operating system in 
+# September 2022. 
+requirements = (OpSysMajorVer == 8)
+#
 # Tell HTCondor what amount of compute resources
 #  each job will need on the computer where it runs.
 request_cpus = 1


### PR DESCRIPTION
This requirements line was added to help new users better understand the transition from CentOS 7 to CentOS Stream 8. It will be removed after September 2022 once the default OS for jobs becomes CentOS Stream 8.