### PR TITLE
Change build job from OS 7 to OS 8

### DIFF
--- a/uw-research-computing/colab-to-chtc.md
+++ b/uw-research-computing/colab-to-chtc.md
@@ -99,7 +99,7 @@ If you don't already have a Docker Hub account before starting this section, cre
     transfer_input_files = requirements.txt, Dockerfile
 
     +IsBuildJob = true
-    requirements = (OpSysMajorVer =?= 7)
+    requirements = (OpSysMajorVer =?= 8)
     request_cpus = 1
     request_memory = 4GB
     request_disk = 16GB


### PR DESCRIPTION
Running podman on OS 7 gives this error: 
```
bash-4.2$  podman login docker.io
cannot clone: Invalid argument
user namespaces are not enabled in /proc/sys/user/max_user_namespaces
Error: could not get runtime: cannot re-exec process
```
Because namespaces are currently disabled. 