### PR TITLE
Add Side navigation to all guides

### DIFF
--- a/_data/guide-menu.yml
+++ b/_data/guide-menu.yml
@@ -1,0 +1,108 @@
+- name: Basics and Policies
+  children:
+    - name: HTC System Transitioning to a New Linux Version (CentOS Stream 8)
+      href: /uw-research-computing/os-transition-htc.html
+    - name: Using CHTC's HTC Submit Nodes
+      href: /uw-research-computing/use-submit-node.html
+    - name: Connecting to CHTC
+      href: /uw-research-computing/connecting.html
+    - name: Automating CHTC Log In
+      href: /uw-research-computing/configure-ssh.html
+    - name: Transferring Files Between CHTC and Research Drive
+      href: /uw-research-computing/transfer-data-researchdrive.html
+    - name: Using Globus to Transfer Files to and from CHTC
+      href: /uw-research-computing/globus.html
+    - name: Remotely Access a Pricate Github Repository
+      href: /uw-research-computing/github-remote-access.html
+    - name: Checking Disk Quota Usage
+      href: /uw-research-computing/check-quota.html
+    - name: Get Help
+      href: /uw-research-computing/get-help.html
+- name: Job Submission
+  children:
+    - name: Running Your First HTC Jobs
+      href: /uw-research-computing/helloworld.html
+    - name: Learning About Your Jobs Using <code>condor_q</code>
+      href: /uw-research-computing/condor_q.html
+    - name: Submitting Multiple Jobs
+      href: /uw-research-computing/multiple-jobs.html
+    - name: Workflows with HTCondor's DAGMan
+      href: /uw-research-computing/dagman-workflows.html
+    - name: Submitting Multiple Jobs in Different Directories
+      href: /uw-research-computing/multiple-job-dirs.html
+- name: Handling Data in Jobs
+  children:
+    - name: Transfer Small Input and Output
+      href: /uw-research-computing/file-availability.html
+    - name: Transfer Large Input Files Via Squid
+      href: /uw-research-computing/file-avail-squid.html
+    - name: Use Large Input and Output Files Via Staging
+      href: /uw-research-computing/file-avail-largedata.html
+- name: Software Solutions
+  children:
+    - name: Compiling Software in an Interactive Job
+      href: /uw-research-computing/inter-submit.html
+    - name: Running Matlab Jobs
+      href: /uw-research-computing/matlab-jobs.html
+    - name: Running Python Jobs
+      href: /uw-research-computing/python-jobs.html
+    - name: Using Conda Environments to Run Python Jobs
+      href: /uw-research-computing/conda-installation.html
+    - name: Running R Jobs
+      href: /uw-research-computing/r-jobs.html
+    - name: Running Julia Jobs
+      href: /uw-research-computing/julia-jobs.html
+    - name: Running Java Jobs
+      href: /uw-research-computing/java-jobs.html
+    - name: Using Software Installed in a Docker Container
+      href: /uw-research-computing/docker-jobs.html
+    - name: Create a Docker Container
+      href: /uw-research-computing/docker-build.html
+    - name: Licensed Software on the HTC System
+      href: /uw-research-computing/licensed-software.html
+    - name: Submitting Jobs that use MPI
+      href: /uw-research-computing/mpi-jobs.html
+- name: Special Use Case
+  children:
+    - name: Submitting Jobs that use GPUs
+      href: /uw-research-computing/gpu-jobs.html
+    - name: Run Machine Learning Jobs
+      href: /uw-research-computing/machine-learning-htc.html
+    - name: Scaling Beyond Local HTC Capacity
+      href: /uw-research-computing/scaling-htc.html
+    - name: Restart Jobs with Checkpointing
+      href: /uw-research-computing/checkpointing.html
+    - name: Submitting Jobs with Checkpointing
+      href: /uw-research-computing/checkpointing.html
+    - name: Submitting High Memory Jobs
+      href: /uw-research-computing/high-memory-jobs.html
+    - name: Submitting Jobs that use MPI
+      href: /uw-research-computing/mpi-jobs.html
+- name: Troubleshooting
+  children:
+    - name: Windows/Linux Incompatibility
+      href: /uw-research-computing/dos-unix.html
+    - name: Explore and Test Docker Containers
+      href: /uw-research-computing/docker-test.html
+- name: HPC Cluster Guides
+  children:
+    - name: Connecting to CHTC
+      href: /uw-research-computing/connecting.html
+    - name: HPC Cluster Overview Guide
+      href: /uw-research-computing/hpc-overview.html
+    - name: HPC Software
+      href: /uw-research-computing/hpc-software.html
+    - name: HPC Job Submission
+      href: /uw-research-computing/hpc-job-submission.html
+    - name: Transitioning to a New HPC Cluster
+      href: /uw-research-computing/hpc-transition-2023.html
+- name: External Resources
+  children:
+    - name: Software Carpentry ( Online courses and videos; readings )
+      href: "http://software-carpentry.org/lessons/"
+    - name: HTCondor Manual
+      href: "http://research.cs.wisc.edu/htcondor/manual/"
+    - name: Slurm Manual
+      href: "http://slurm.schedmd.com/"
+    - name: DoIT Software Training for Students ( free on-campus courses )
+      href: "http://www.doit.wisc.edu/training/student/"

--- a/_data/uw-research-computing-menu.yml
+++ b/_data/uw-research-computing-menu.yml
@@ -1,13 +1,10 @@
 nav_items:
   - id: home
     name: Home
-    url: /index.html
-  - id: uw-research-computing
-    name: UW Research Computing
     url: /uw-research-computing/index.html
   - id: get-started
     name: Get Started
-    url: /uw-research-computing/get-started.html
+    url: /uw-research-computing/form.html
   - id: menu-how-tos
     name: How To's
     url: /uw-research-computing/how-tos.html

--- a/_includes/guide-sidebar.liquid
+++ b/_includes/guide-sidebar.liquid
@@ -1,10 +1,15 @@
 {% assign data = site.data.guide-menu %}
+{% assign added = "" | split: "" %}
 
 <div id="guide-sidebar">
     <h6 class="mt-5">Guides</h6>
     <div class="accordion accordion-flush">
         {% for category in data %}
             {% assign active = category.children | where_exp: "x", "x.href == page.url" %}
+            {% assign used = added | where_exp: "x", "x.href == active[0].href" %}
+            {% if used.size == 1 %}
+                {% assign active = "" | split: "" %}
+            {% endif %}
             <div class="accordion-item">
                 <h2 class="accordion-header mt-0" id="{{ category.name | slugify }}">
                     <button class="accordion-button {% unless active.size == 1 %}collapsed {% endunless %}" type="button" data-bs-toggle="collapse" data-bs-target="#{{ category.name | slugify }}-collapse" aria-expanded="false" aria-controls="{{ category.name | slugify }}">
@@ -13,6 +18,8 @@
                 </h2>
                 <div id="{{ category.name | slugify }}-collapse" class="accordion-collapse collapse {% if active.size == 1 %}show {% endif %}" aria-labelledby="{{ category.name | slugify }}" data-bs-parent="#guide-sidebar">
                     {% for document in category.children %}
+                        {% assign added = added |  push: document %}
+
                         <div class="document-link-wrapper">
                             <a class="{% if active[0].href == document.href %}fw-bolder{% endif %}" href="{{ document.href }}">{{ document.name }}</a>
                         </div>
@@ -22,3 +29,4 @@
         {% endfor %}
     </div>
 </div>
+<script>console.log({{ added |  jsonify }})</script>

--- a/_includes/guide-sidebar.liquid
+++ b/_includes/guide-sidebar.liquid
@@ -29,4 +29,3 @@
         {% endfor %}
     </div>
 </div>
-<script>console.log({{ added |  jsonify }})</script>

--- a/_includes/guide-sidebar.liquid
+++ b/_includes/guide-sidebar.liquid
@@ -4,16 +4,17 @@
     <h6 class="mt-5">Guides</h6>
     <div class="accordion accordion-flush">
         {% for category in data %}
+            {% assign active = category.children | where_exp: "x", "x.href == page.url" %}
             <div class="accordion-item">
                 <h2 class="accordion-header mt-0" id="{{ category.name | slugify }}">
-                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#{{ category.name | slugify }}-collapse" aria-expanded="false" aria-controls="{{ category.name | slugify }}">
+                    <button class="accordion-button {% unless active.size == 1 %}collapsed {% endunless %}" type="button" data-bs-toggle="collapse" data-bs-target="#{{ category.name | slugify }}-collapse" aria-expanded="false" aria-controls="{{ category.name | slugify }}">
                         {{ category.name }}
                     </button>
                 </h2>
-                <div id="{{ category.name | slugify }}-collapse" class="accordion-collapse collapse" aria-labelledby="{{ category.name | slugify }}" data-bs-parent="#guide-sidebar">
+                <div id="{{ category.name | slugify }}-collapse" class="accordion-collapse collapse {% if active.size == 1 %}show {% endif %}" aria-labelledby="{{ category.name | slugify }}" data-bs-parent="#guide-sidebar">
                     {% for document in category.children %}
                         <div class="document-link-wrapper">
-                            <a class="" href="{{ document.href }}">{{ document.name }}</a><br>
+                            <a class="{% if active[0].href == document.href %}fw-bolder{% endif %}" href="{{ document.href }}">{{ document.name }}</a>
                         </div>
                     {% endfor %}
                 </div>

--- a/_includes/guide-sidebar.liquid
+++ b/_includes/guide-sidebar.liquid
@@ -1,0 +1,23 @@
+{% assign data = site.data.guide-menu %}
+
+<div id="guide-sidebar">
+    <h6 class="mt-5">Guides</h6>
+    <div class="accordion accordion-flush">
+        {% for category in data %}
+            <div class="accordion-item">
+                <h2 class="accordion-header mt-0" id="{{ category.name | slugify }}">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#{{ category.name | slugify }}-collapse" aria-expanded="false" aria-controls="{{ category.name | slugify }}">
+                        {{ category.name }}
+                    </button>
+                </h2>
+                <div id="{{ category.name | slugify }}-collapse" class="accordion-collapse collapse" aria-labelledby="{{ category.name | slugify }}" data-bs-parent="#guide-sidebar">
+                    {% for document in category.children %}
+                        <div class="document-link-wrapper">
+                            <a class="" href="{{ document.href }}">{{ document.name }}</a><br>
+                        </div>
+                    {% endfor %}
+                </div>
+            </div>
+        {% endfor %}
+    </div>
+</div>

--- a/_includes/guide-sidebar.liquid
+++ b/_includes/guide-sidebar.liquid
@@ -21,7 +21,7 @@
                         {% assign added = added |  push: document %}
 
                         <div class="document-link-wrapper">
-                            <a class="{% if active[0].href == document.href %}fw-bolder{% endif %}" href="{{ document.href }}">{{ document.name }}</a>
+                            <a class="{% if active[0].href == document.href %}fw-bolder{% endif %}" href="{{ document.href | relative_url }}">{{ document.name }}</a>
                         </div>
                     {% endfor %}
                 </div>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -26,12 +26,13 @@
 {% include analytics.html %}
 {% endif %}
 
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous" defer></script>
 <script type="text/javascript" src="{{ '/assets/js/uw-style.js' | relative_url }}" defer></script>
 <script src="{{ '/assets/js/lunr.js' | relative_url }}" type="text/javascript" async></script>
 <script type="text/javascript" src="{{ '/assets/js/search_bar.js' | relative_url }}" defer></script>
 
 <link type="text/css" href="{{ '/assets/fonts/fonts.0.0.1.css' | relative_url }}" rel="stylesheet">
-<link type="text/css" href="{{ '/assets/css/style-v3.css' | relative_url }}" rel="stylesheet">
+<link type="text/css" href="{{ '/assets/css/style-v5.css' | relative_url }}" rel="stylesheet">
 {% include logic/is_in_uw_dir.html %}
 {% if is_in_uw_dir %}<link type="text/css" href="{{ '/assets/css/research-style.css' | relative_url }}" rel="stylesheet">{% endif %}
 

--- a/_layouts/file_avail.html
+++ b/_layouts/file_avail.html
@@ -1,6 +1,6 @@
 ---
 title: File Available
-layout: markdown-page
+layout: guide
 ---
 
 <h2>Which Option is the Best for Your Files?</h2>

--- a/_layouts/guide.html
+++ b/_layouts/guide.html
@@ -1,0 +1,15 @@
+---
+layout: main
+---
+
+<div class="container-xxl mb-5">
+    <div class="row justify-content-center">
+        <div class="col-12 col-lg-9 mw-1000">
+            {% include page-title.html title=page.title %}
+            {{ content }}
+        </div>
+        <div class="col-3 d-none d-lg-block">
+            {% include guide-sidebar.liquid %}
+        </div>
+    </div>
+</div>

--- a/_layouts/hpc_layout.html
+++ b/_layouts/hpc_layout.html
@@ -5,18 +5,20 @@ layout: default
 
 {% include hpc-header.html %}
 
-<div class="container-xxl">
+<div class="container-xxl mb-5">
     <div class="row justify-content-center">
-        <div class="col mw-1000" markdown="block">        	
+        <div class="col-12 col-lg-9 mw-1000">
             {% include page-title.html title=page.title %}
-            
-            <blockquote>These guides have been recently updated with information 
-        	about the new "Spark" HPC cluster. For a full summary of changes and 
-        	recommended actions to transition jobs from the old cluster to Spark, 
-        	see this <a href="https://chtc.cs.wisc.edu/uw-research-computing/hpc-transition-2023">transition guide</a></blockquote>
-            
+            <blockquote>
+                These guides have been recently updated with information
+                about the new "Spark" HPC cluster. For a full summary of changes and
+                recommended actions to transition jobs from the old cluster to Spark,
+                see this <a href="https://chtc.cs.wisc.edu/uw-research-computing/hpc-transition-2023">transition guide</a>
+            </blockquote>
             {{ content }}
+        </div>
+        <div class="col-3 d-none d-lg-block">
+            {% include guide-sidebar.liquid %}
         </div>
     </div>
 </div>
-

--- a/assets/css/style-v5.scss
+++ b/assets/css/style-v5.scss
@@ -14,6 +14,10 @@ $primary: #c5050c;
 
 $uw-max-content-width: 1320px;
 
+$accordion-padding-x: 0;
+$accordion-padding-y: .5em;
+$accordion-icon-width: .9rem;
+
 // Bootstrap
 @import 'bootstrap/bootstrap';
 
@@ -164,4 +168,39 @@ html {
   background-size: cover;
 
   box-shadow: inset 0px 0px 10px white;
+}
+
+#guide-sidebar {
+
+  top: 1rem;
+  position: sticky;
+  line-height: 1rem;
+
+  .accordion-button {
+    transition: padding .2s;
+    transition-timing-function: ease-out;
+  }
+  .accordion-button:focus {
+    padding-left: 0.4rem;
+    padding-right: 0.4rem;
+  }
+  .accordion-button:not(.collapsed) {
+    padding-left: 0.4rem;
+    padding-right: 0.4rem;
+  }
+  .document-link-wrapper {
+    border-bottom: 1px solid rgba(0,0,0,0.125);
+    padding: .4rem;
+    background-color: #fffcfc;
+  }
+  button {
+    font-size: 1rem;
+  }
+  a {
+    font-size: .9rem;
+    color: black;
+  }
+  a:hover {
+    color: $primary;
+  }
 }

--- a/uw-research-computing/check-quota.md
+++ b/uw-research-computing/check-quota.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Checking Disk Quota and Usage
 ---
 

--- a/uw-research-computing/checkpointing.md
+++ b/uw-research-computing/checkpointing.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Checkpointing Jobs
 ---
 

--- a/uw-research-computing/cite-chtc.md
+++ b/uw-research-computing/cite-chtc.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Citing CHTC Resources
 ---
 

--- a/uw-research-computing/colab-to-chtc.md
+++ b/uw-research-computing/colab-to-chtc.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Going from Google Colab to CHTC's GPU Lab
 published: true
 ---

--- a/uw-research-computing/conda-installation.md
+++ b/uw-research-computing/conda-installation.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Create a Portable Python Installation with Miniconda
 ---
 

--- a/uw-research-computing/condor_q.md
+++ b/uw-research-computing/condor_q.md
@@ -1,16 +1,14 @@
 ---
 highlighter: none
-layout: content
+layout: guide
 title: Learning About Your Jobs Using condor_q
 ---
 
-{% capture content %}
+
 The `condor_q` command can be used for much more than just
 checking on whether your jobs are running or not! Read on to learn how
 you can use `condor_q` to answer many common questions about running
 jobs.
-{% endcapture %}
-{% include /components/markdown-container.html %}
 
 {% capture content %}
 1.  [Default `condor_q` output, in \"batches\"](#default-condorq-output)
@@ -27,7 +25,7 @@ jobs.
 {% endcapture %}
 {% include /components/directory.html %}  
 
-{% capture content %}
+
 Summary
 =======
 
@@ -361,5 +359,3 @@ This will remove the job in the queue. Once you have made changes to allow the j
 This page takes some of its content and formatting from [this HTCondor
 reference
 page](http://vivaldi.ll.iac.es/sieinvens/siepedia/pmwiki.php?n=HOWTOs.CondorUsefulCommands).
-{% endcapture %}
-{% include /components/markdown-container.html %}

--- a/uw-research-computing/configure-ssh.md
+++ b/uw-research-computing/configure-ssh.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Automating CHTC Log In
 ---
 

--- a/uw-research-computing/connecting.md
+++ b/uw-research-computing/connecting.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Connecting to CHTC 
 ---
 

--- a/uw-research-computing/containers-beyond-chtc.md
+++ b/uw-research-computing/containers-beyond-chtc.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Running Jobs Beyond CHTC Using Containers
 ---
 

--- a/uw-research-computing/dagman-workflows.md
+++ b/uw-research-computing/dagman-workflows.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Workflows with HTCondor's DAGMan
 ---
 

--- a/uw-research-computing/dask.md
+++ b/uw-research-computing/dask.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Using Dask at CHTC
 ---
 

--- a/uw-research-computing/docker-build.md
+++ b/uw-research-computing/docker-build.md
@@ -1,5 +1,5 @@
 ---
-layout: markdown-page
+layout: guide
 title: Building a Docker Container Image
 ---
 

--- a/uw-research-computing/docker-jobs.md
+++ b/uw-research-computing/docker-jobs.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Running HTC Jobs Using Docker Containers
 ---
 

--- a/uw-research-computing/docker-test.md
+++ b/uw-research-computing/docker-test.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Exploring a Docker Container on Your Computer
 ---
 

--- a/uw-research-computing/dos-unix.md
+++ b/uw-research-computing/dos-unix.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Windows / Linux Incompatibility
 ---
 

--- a/uw-research-computing/file-avail-largedata-test.md
+++ b/uw-research-computing/file-avail-largedata-test.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Managing Large Data in HTC Jobs
 published: false
 ---

--- a/uw-research-computing/get-submit-node.md
+++ b/uw-research-computing/get-submit-node.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Getting a Submit Node
 ---
 

--- a/uw-research-computing/github-remote-access.md
+++ b/uw-research-computing/github-remote-access.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Remotely Access a Private GitHub Repository
 ---
 

--- a/uw-research-computing/globus.md
+++ b/uw-research-computing/globus.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Using Globus to Transfer Files to and from CHTC
 ---
 

--- a/uw-research-computing/gpu-jobs.md
+++ b/uw-research-computing/gpu-jobs.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Jobs That Use GPUs
 ---
 

--- a/uw-research-computing/helloworld.md
+++ b/uw-research-computing/helloworld.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Running Your First CHTC Jobs
 ---
 

--- a/uw-research-computing/high-memory-jobs.md
+++ b/uw-research-computing/high-memory-jobs.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Submitting High Memory Jobs on CHTC's HTC System
 ---
 

--- a/uw-research-computing/hpc-transition-2023.md
+++ b/uw-research-computing/hpc-transition-2023.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Transitioning to a New HPC Cluster
 published: true
 ---

--- a/uw-research-computing/inter-submit.md
+++ b/uw-research-computing/inter-submit.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Compiling or Testing Code with an Interactive Job
 ---
 

--- a/uw-research-computing/java-jobs.md
+++ b/uw-research-computing/java-jobs.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Using Java Code in CHTC
 ---
 

--- a/uw-research-computing/julia-jobs.md
+++ b/uw-research-computing/julia-jobs.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Running Julia Jobs on CHTC
 ---
 

--- a/uw-research-computing/licensed-software.md
+++ b/uw-research-computing/licensed-software.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Using Licensed Software in CHTC
 ---
 

--- a/uw-research-computing/machine-learning-htc.md
+++ b/uw-research-computing/machine-learning-htc.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Run Machine Learning Jobs on the HTC system
 ---
 

--- a/uw-research-computing/matlab-jobs.md
+++ b/uw-research-computing/matlab-jobs.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Running Matlab Jobs on CHTC 
 ---
 

--- a/uw-research-computing/mpi-jobs.md
+++ b/uw-research-computing/mpi-jobs.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Running MPI Jobs in CHTC
 ---
 

--- a/uw-research-computing/multiple-job-dirs.md
+++ b/uw-research-computing/multiple-job-dirs.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Submitting Multiple Jobs in Individual Directories
 ---
 

--- a/uw-research-computing/multiple-jobs.md
+++ b/uw-research-computing/multiple-jobs.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Submitting Multiple Jobs Using HTCondor
 ---
 

--- a/uw-research-computing/os-transition-htc.md
+++ b/uw-research-computing/os-transition-htc.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: HTC System Transition to a New Linux Version (CentOS Stream 8)
 published: true
 ---

--- a/uw-research-computing/python-jobs.md
+++ b/uw-research-computing/python-jobs.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Running Python Jobs on CHTC
 ---
 

--- a/uw-research-computing/r-build.md
+++ b/uw-research-computing/r-build.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Building R in HTC
 ---
 

--- a/uw-research-computing/r-jobs.md
+++ b/uw-research-computing/r-jobs.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Running R Jobs on CHTC
 ---
 

--- a/uw-research-computing/scaling-htc.md
+++ b/uw-research-computing/scaling-htc.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Scaling Beyond Local HTC Capacity
 ---
 

--- a/uw-research-computing/singularity-hpc.md
+++ b/uw-research-computing/singularity-hpc.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Using Software in a Container on the HPC Cluster
 ---
 

--- a/uw-research-computing/tensorflow-singularity-wait.md
+++ b/uw-research-computing/tensorflow-singularity-wait.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Running Tensorflow Jobs
 ---
 

--- a/uw-research-computing/tensorflow-singularity.md
+++ b/uw-research-computing/tensorflow-singularity.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Running Tensorflow Jobs
 ---
 

--- a/uw-research-computing/testing-jobs.md
+++ b/uw-research-computing/testing-jobs.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Importance of Testing
 ---
 

--- a/uw-research-computing/transfer-data-researchdrive.md
+++ b/uw-research-computing/transfer-data-researchdrive.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Transferring Files Between CHTC and ResearchDrive
 ---
 

--- a/uw-research-computing/use-submit-node.md
+++ b/uw-research-computing/use-submit-node.md
@@ -1,6 +1,6 @@
 ---
 highlighter: none
-layout: markdown-page
+layout: guide
 title: Policies for Using HTC Submit Servers
 ---
 


### PR DESCRIPTION
Adds side nav to all guides when the screen is wide enough (1000px). 
Any double listed docs expand the first category they are in.

#### Preview:
- https://chtc.github.io/web-preview/preview-side-nav
- Added an image with the automatic side bar open and highlighting on guides as that breaks with the extra url bits included in the preview link.

#### Review 
Just confirm that this adds value and you want it merged. No need for a technical review.


