### PR TITLE
Update guides.html

### DIFF
--- a/uw-research-computing/guides.html
+++ b/uw-research-computing/guides.html
@@ -76,7 +76,7 @@ Guides will be added to the list as we can provide them. Please contact us
 			<a href="{{ '/uw-research-computing/condor_q.html' | relative_url }}"><li class="list-group-item list-group-item-action list-group-item-dark h-100" style="width: auto; height: auto !important; border-radius: 1px;">Learning About Your Jobs Using <code>condor_q</code></li></a>
 			<a href="{{ '/uw-research-computing/multiple-jobs.html' | relative_url }}"><li class="list-group-item list-group-item-action list-group-item-dark h-100" style="width: auto; height: auto !important; border-radius: 1px;">Submitting Multiple Jobs</li></a>
 			<a href="{{ '/uw-research-computing/dagman-workflows.html' | relative_url }}"><li class="list-group-item list-group-item-action list-group-item-dark h-100" style="width: auto; height: auto !important; border-radius: 1px;">Workflows with HTCondor's DAGMan</li></a>
-			<a href="{{ '/uw-research-computing/multiple-job-dirs.html' | relative_url }}"><li class="list-group-item list-group-item-action list-group-item-dark h-100" style="width: auto; height: auto !important;">Submitting Multiple Jobs in Different Directories</li></a>
+			<a href="{{ '/uw-research-computing/multiple-job-dirs.html' | relative_url }}"><li class="list-group-item list-group-item-action list-group-item-dark h-100" style="width: auto; height: auto !important;">Submitting Multiple Jobs in Individual Directories</li></a>
 		</ul>
 	</div>
 


### PR DESCRIPTION
Changing from "Submitting Multiple Jobs in Different Directories" to "Submitting Multiple Jobs in Individual Directories" to match the title of the actual page (which uses 'Individual', not 'Different').