### PR TITLE
Updating HPC pages with comment giving `--mem-per-cpu` units

### DIFF
--- a/_uw-research-computing/hpc-job-submission.md
+++ b/_uw-research-computing/hpc-job-submission.md
@@ -74,7 +74,7 @@ Once the submit file is created, it can be submitted using the `sbatch` command:
 **B. Optimizing Your Submit File**
 -------------------
 
-The new cluster has different partition names and different sized nodes. We  recommend the following changes because most of our nodes now have 128 cores, so requesting multiple nodes is not advantageous if your jobs are smaller than 128 cores. We also now recommend requesting memory per core instead of memory per node, for similar reasons. Here are our recommendations for different sized jobs:
+The new cluster has different partition names and different sized nodes. We  recommend the following changes because most of our nodes now have 128 cores, so requesting multiple nodes is not advantageous if your jobs are smaller than 128 cores. We also now recommend requesting memory per core instead of memory per node, for similar reasons, using the `--mem-per-cpu` flag with units of MB. Here are our recommendations for different sized jobs: 
 
 <table>
 	<tr>

--- a/_uw-research-computing/hpc-transition-2023.md
+++ b/_uw-research-computing/hpc-transition-2023.md
@@ -81,8 +81,8 @@ different sized nodes. The main general use partition is now called `shared`
 instead of `univ2` or `univ3`. We also recommend the following changes because 
 most of our nodes now have 128 cores, so requesting multiple nodes is not 
 advantageous if your jobs are smaller than 128 cores. We also now recommend requesting 
-memory per core instead of memory per node, for similar reasons. Here are our recommendations 
-for different sized jobs: 
+memory per core instead of memory per node, for similar reasons, using the `--mem-per-cpu`
+flag with units of MB. Here are our recommendations for different sized jobs: 
 
 <table>
 	<tr>


### PR DESCRIPTION
While the units of MB are implied for the `--mem-per-cpu` flag, I think it would be helpful to be explicit.