### PR TITLE
Update to helloworld guide

### DIFF
--- a/_uw-research-computing/helloworld.md
+++ b/_uw-research-computing/helloworld.md
@@ -144,13 +144,10 @@ Submitting job(s).....
 
 **4.** To check on the status of your jobs, run the following command:
 
-{:.term}
 ``` 
 [alice@submit]$ condor_q
 ```
-
-
-(If you want to see everyone\'s jobs, use `condor_q -all`.)
+{:.term}
 
 The output of `condor_q` should look like this:
 

--- a/_uw-research-computing/helloworld.md
+++ b/_uw-research-computing/helloworld.md
@@ -46,6 +46,7 @@ describes the set of jobs.
 
 ***Note: You must be logged into an HTCondor submit machine for the
 following example to work.***
+See the [Connecting to CHTC](connecting.html) guide for more information on how to log in.
 
 **1.** Copy the highlighted text below, and paste it into file called
 `hello-chtc.sub` (we recommend using a command line text editor) in your home directory on the submit
@@ -168,6 +169,12 @@ batch name (if provided), or executable name. To show all of your jobs
 on individual lines, add the `-nobatch` option. For more details on this
 option, and other options to `condor_q`, see our [condor\_q
 guide](condor_q.html).
+
+Alternately, you can run the `condor_watch_q` command to display the
+status of your jobs in the queue along with color-coded progress bars.
+The display is updated automatically every couple seconds, allowing you
+to monitor the status of your jobs in real time.  To exit the view,
+use the keyboard shortcut `Ctrl` + `c`.
 
 > **Potential Failures**
 >


### PR DESCRIPTION
Added a couple sentences for using `condor_watch_q`.
Removed mention of `condor_q -all` (doesn't seem relevant to the regular user).

Preview at https://chtc.github.io/web-preview/preview-htc-hello-world-update/uw-research-computing/helloworld 