### PR TITLE
Fix code in headings

### DIFF
--- a/_uw-research-computing/configure-ssh.md
+++ b/_uw-research-computing/configure-ssh.md
@@ -149,7 +149,7 @@ downloaded or edited, but some do not.
     1. Under “Transfers”, use the “Transfer Files” drop-down to select “Use browser 
 connection”.
 
-<h3>Known to NOT support <code class="h2">ControlMaster</code> or similar persistent connections</h3>
+<h3>Known to NOT support <code class="h3">ControlMaster</code> or similar persistent connections</h3>
 
 * Windows PowerShell
 

--- a/_uw-research-computing/configure-ssh.md
+++ b/_uw-research-computing/configure-ssh.md
@@ -149,7 +149,7 @@ downloaded or edited, but some do not.
     1. Under “Transfers”, use the “Transfer Files” drop-down to select “Use browser 
 connection”.
 
-### Known to NOT support `ControlMaster` or similar persistent connections
+<h3>Known to NOT support <code class="h2">ControlMaster</code> or similar persistent connections</h3>
 
 * Windows PowerShell
 

--- a/_uw-research-computing/docker-build.md
+++ b/_uw-research-computing/docker-build.md
@@ -70,7 +70,7 @@ multiple images for different parts of your workflow,
 you should create a separate folder for each 
 new image with the a ``Dockerfile`` inside each of them.
 
-### Choose a base image with `FROM`
+<h3>Choose a base image with <code class="h3">FROM</code></h3>
 
 Usually you don't want to start building your image from scratch. 
 Instead you'll want to choose a "base" image to add things to.
@@ -126,7 +126,7 @@ Here are some base images you might find useful to build off of:
 - [Tensorflow](https://hub.docker.com/r/tensorflow/tensorflow)
 - [PyTorch](https://hub.docker.com/r/pytorch/pytorch)
 
-### Install packaged software with `RUN`
+<h3>Install packaged software with <code class="h3">RUN</code></h3>
 
 The next step is the most challenging. We need to add commands to the
 Dockerfile to install the desired software. There are a few standard ways to
@@ -197,7 +197,7 @@ RUN install2.r --error rjags
 ```
 {:.file}
 
-### Set up the environment with `ENV`
+<h3>Set up the environment with <code class="h3">ENV</code></h3>
 
 Your software might rely on certain environment variables being set correctly.
 

--- a/_uw-research-computing/file-availability.md
+++ b/_uw-research-computing/file-availability.md
@@ -195,7 +195,7 @@ directory.
 
 <a name="select"></a>
 
-## Select Specific Output Files To Transfer to `/home`
+<h2>Select Specific Output Files to Transfer to <code class="h2">/home</code></h2>
 
 As described above, <a href="http://research.cs.wisc.edu/htcondor/">HTCondor</a> will transfer ALL new or modified files in the top level 
 directory of the job (where it ran on the execute server), back to the job's initial directory 

--- a/_uw-research-computing/gpu-jobs.md
+++ b/_uw-research-computing/gpu-jobs.md
@@ -281,7 +281,7 @@ or less, or have implemented self-checkpointing (the capability to save progress
 to a file and restart from that progress). Use the `is_resumable` option shown 
 above in the [list of submit file options](#1-choose-gpu-related-submit-file-options). 
 
-## 2. Use the `gzk` Servers
+<h2>2. Use the <code class="h2">gzk</code> Servers</h2>
 
 These are servers that are similar to the GPU Lab severs with two important differences 
 for running GPU jobs: 

--- a/_uw-research-computing/multiple-jobs.md
+++ b/_uw-research-computing/multiple-jobs.md
@@ -28,7 +28,7 @@ HTCondor. If you are interested in a particular approach that isn't described he
 please contact [CHTC's research computing facilitators](mailto:chtc@cs.wisc.edu) and we will 
 work with you to identify options to meet the needs of your work.
 
-# Submit Multiple Jobs Using `queue`
+<h1>Submit Multiple Jobs Using <code class="h1">queue</code></h1>
 
 All HTCondor submit files require a `queue` attribute (which must also be 
 the last line of the submit file). By default, `queue` will submit one job, but 
@@ -63,7 +63,7 @@ like input file names, file locations (aka paths), etc. **When selecting a
 variable name, users must avoid bespoke HTCondor submit file variables 
 such as `Cluster`, `Process`, `output`, and `input`, `arguments`, etc.**
 
-## 1. Use `queue N` in you HTCondor submit files<a name="process"></a>
+<h2>1. Use <code class="h2">queue N</code> in your HTCondor submit files</h2><a name="process"></a>
 
 When using `queue N`, HTCondor will submit a total of *N* 
 jobs, counting from 0 to *N* - 1 and each job will be assigned 


### PR DESCRIPTION
Changes to code in headings to resolve and close #570.  

Changes described in https://opensciencegrid.atlassian.net/browse/CR-103 and sub tasks.

Preview at https://chtc.github.io/web-preview/preview-fix-code-in-headings/uw-research-computing/.

Compare, for example, https://chtc.github.io/web-preview/preview-fix-code-in-headings/uw-research-computing/multiple-jobs (new) versus https://chtc.cs.wisc.edu/uw-research-computing/multiple-jobs (old).