### PR TITLE
OSPool doesn't support Docker, only Singularity/Apptainer

### DIFF
--- a/_uw-research-computing/docker-jobs.md
+++ b/_uw-research-computing/docker-jobs.md
@@ -25,7 +25,7 @@ advantageous if the software installation 1) has many dependencies, 2)
 requires installation to a specific location, or 3) "hard-codes" paths
 into the installation.
 
-CHTC (and the OS Pool) have capabilities to access and start containers and
+CHTC has capabilities to access and start containers and
 run jobs inside them. This guide shows how to do this for
 [Docker](https://www.docker.com/what-docker) containers.
 


### PR DESCRIPTION
We don't want people using docker:// URLs in OSPool so don't mention it in this doc.