### PR TITLE
align matlab versions with available modules

### DIFF
--- a/_uw-research-computing/matlab-jobs.md
+++ b/_uw-research-computing/matlab-jobs.md
@@ -46,8 +46,7 @@ Supported Versions of Matlab
   | --- |
   | Matlab 2015b | 
   | Matlab 2018b |
-  | Matlab 2020a | 
-  | Matlab 2021b | 
+  | Matlab 2022b | 
 
 
 **A. Preparing Your Matlab Program** 
@@ -251,8 +250,7 @@ executable = run_script.sh
     
     -   `r2015b.tar.gz`
     -   `r2018b.tar.gz`
-    -   `r2020a.tar.gz`
-    -   `r2021b.tar.gz`<br>
+    -   `r2022b.tar.gz`<br>
     
     To send the runtime package to your jobs, list a link to the
     appropriate version in your `transfer_input_files` line, as well as
@@ -270,8 +268,7 @@ executable = run_script.sh
       | --- | --- |
       | `r2015b.tar.gz` | `v90` |
       | `r2018b.tar.gz` | `v95` |
-      | `r2020a.tar.gz` | `v98` | 
-      | `r2021b.tar.gz` | `v911` | 
+      | `r2022b.tar.gz` | `R2022b` | 
  
     So to run a Matlab job using `r2015b` and no additional arguments, the arguments line in the submit file should read:
     ```{:.sub}
@@ -289,7 +286,7 @@ executable = run_script.sh
 4.  As always, test a few jobs for disk space/memory usage in order to
     make sure your requests for a large batch are accurate! Disk space
     and memory usage can be found in the log file after the job
-    completes. **If you are using Matlab 2018b, request at least 5.5GB
+    completes. **If you are using Matlab 2018b or 2022b, request at least 8-10GB
     of DISK** as the runtime is very large for this version of Matlab.
 
 <a name="random"></a>


### PR DESCRIPTION
I've put the 2022b tarball into squid but it hasn't been tested. 🙃 