### PR TITLE
Attempting to fix broken links in spack guides

### DIFF
--- a/_uw-research-computing/hpc-spack-install.md
+++ b/_uw-research-computing/hpc-spack-install.md
@@ -13,7 +13,7 @@ CHTC uses Spack ([https://github.com/spack/spack](https://github.com/spack/spack
 
 **This guide describes how to install and manage software using Spack, including how to install and use a specific compiler.** 
 
-**This guide assumes you or your group has already set up your local installation of Spack.** If you have not installed Spack, follow the instructions in [Setting Up Spack on HPC](hpc-spack-setup.md).
+**This guide assumes you or your group has already set up your local installation of Spack.** If you have not installed Spack, follow the instructions in [Setting Up Spack on HPC](hpc-spack-setup.html).
 
 
 # Contents
@@ -151,7 +151,7 @@ since the interactive session will start with the environment deactivated.
 
 ### ii. Create the local scratch directory
 
-Using the default configuration from [Setting Up Spack on HPC](hpc-spack-setup.md), Spack will try to use the machine's local disk space for staging and compiling files before transferring the finished results to the final installation directory.  Using this space will greatly improve the speed of the installation process. Create the local directory with the command
+Using the default configuration from [Setting Up Spack on HPC](hpc-spack-setup.html), Spack will try to use the machine's local disk space for staging and compiling files before transferring the finished results to the final installation directory.  Using this space will greatly improve the speed of the installation process. Create the local directory with the command
 
 ```
 mkdir /local/yourNetID/spack_build
@@ -233,7 +233,7 @@ rm -rf /local/yourNetID/spack_build
 
 and then enter `exit` to end the interactive session.
 
-To use the packages that you installed, follow the instructions in the next section, [2. Using Software Installed in Spack](2-using-software-installed-in-spack). If you want to create custom modules using the installed packages, see our guide [Creating Custom Modules Using Spack](hpc-spack-modules.md).
+To use the packages that you installed, follow the instructions in the next section, [2. Using Software Installed in Spack](2-using-software-installed-in-spack). If you want to create custom modules using the installed packages, see our guide [Creating Custom Modules Using Spack](hpc-spack-modules.html).
 
 ## E. Removing an Environment and Uninstalling Unneeded Packages
 
@@ -306,7 +306,7 @@ srun --mpi=pmix -n 64 /home/username/mpiprogram
 
 When you submit this job to Slurm and it executes the commands in the `sbatch` file, it will first activate the Spack environment, and then your program will be run using the programs that are installed inside that environment.
 
-> Some programs include explicit `module load` commands in their execution, which may override the paths provided by the Spack environment. If your program appears to use the system versions of the packages instead of the versions installed in your Spack environment, you may need to remove or modify these explicit commands. Consult your program's documentation for how to do so. You may want to create your own custom modules and modify your program to explicitly load your custom modules. See [Creating Custom Modules Using Spack](hpc-spack-modules.md) for more information on how to create your own modules using Spack.
+> Some programs include explicit `module load` commands in their execution, which may override the paths provided by the Spack environment. If your program appears to use the system versions of the packages instead of the versions installed in your Spack environment, you may need to remove or modify these explicit commands. Consult your program's documentation for how to do so. You may want to create your own custom modules and modify your program to explicitly load your custom modules. See [Creating Custom Modules Using Spack](hpc-spack-modules.html) for more information on how to create your own modules using Spack.
 
 # 3. Installing and Using a Specific Compiler
 

--- a/_uw-research-computing/hpc-spack-modules.md
+++ b/_uw-research-computing/hpc-spack-modules.md
@@ -11,7 +11,7 @@ guide:
 
 CHTC uses Spack ([https://github.com/spack/spack](https://github.com/spack/spack)) for installing and managing software packages on the HPC cluster for all users to use, via the `module` command. Recently, Spack has developed a feature that allows for users to integrate their local installation of Spack with the system-wide installation. This means that when a user installs software with their local installation of Spack, they can automatically incorporate the system-wide packages to satisfy their software's dependencies (similar to Conda and Miniconda). 
 
-**This guide describes how to create and use custom personal and shared modules for software packages installed using Spack.** For instructions on how to install software using Spack for you and/or your research group, see our guide [Installing Software Using Spack](hpc-spack-install.md). 
+**This guide describes how to create and use custom personal and shared modules for software packages installed using Spack.** For instructions on how to install software using Spack for you and/or your research group, see our guide [Installing Software Using Spack](hpc-spack-install.html). 
 
 
 # Contents
@@ -26,9 +26,9 @@ CHTC uses Spack ([https://github.com/spack/spack](https://github.com/spack/spack
 
 In order to load a software package using the `module` command, there must be a corresponding "module file" containing the information that the `module` command needs in order to load the software package. Spack will automatically generate the required content of the module files, but Spack will need to know where these module files should be saved. Similarly, the `module` command will need to know where the module files are stored.
 
-If you followed the instructions in [Setting Up Spack on HPC](hpc-spack-setup.md), then **the default location of your module files is `/home/yourNetID/spack_modules`** where `yourNetID` is your NetID. 
+If you followed the instructions in [Setting Up Spack on HPC](hpc-spack-setup.html), then **the default location of your module files is `/home/yourNetID/spack_modules`** where `yourNetID` is your NetID. 
 
-> **If you are using a shared installation of Spack for a group**, and if the person who set up the installation followed the instructions in [Setting Up Spack on HPC](hpc-spack-setup.md), then the default location of the shared module files is likely `/home/groups/yourGroupName/spack_modules`. You can confirm this by running the command `spack config get modules | grep -A 2 'roots'` and examining the listed paths (make sure you do not have a Spack environment activated when you do so). If the paths are `/home/$user/spack_modules`, then you should follow the instructions in [iii. Updating location of module files](hpc-spack-setup.md#iii-updating-location-of-module-files) in [Setting Up Spack on HPC](hpc-spack-setup.md) before proceeding.
+> **If you are using a shared installation of Spack for a group**, and if the person who set up the installation followed the instructions in [Setting Up Spack on HPC](hpc-spack-setup.html), then the default location of the shared module files is likely `/home/groups/yourGroupName/spack_modules`. You can confirm this by running the command `spack config get modules | grep -A 2 'roots'` and examining the listed paths (make sure you do not have a Spack environment activated when you do so). If the paths are `/home/$user/spack_modules`, then you should follow the instructions in [iii. Updating location of module files](hpc-spack-setup.html#iii-updating-location-of-module-files) in [Setting Up Spack on HPC](hpc-spack-setup.html) before proceeding.
 
 # 2. Using Custom Modules
 
@@ -148,4 +148,4 @@ spack module refresh lmod --delete-tree
 ```
 {:.term}
 
-More advanced options regarding the naming and structure of the `lmod` module files can be configured by editing the `modules.yaml` (described in  [iii. Updating location of module files](hpc-spack-setup.md#iii-updating-location-of-module-files) in [Setting Up Spack on HPC](hpc-spack-setup.md)). See the Spack documentation for more information on how to configure module files: https://spack.readthedocs.io/en/latest/module_file_support.html#.
+More advanced options regarding the naming and structure of the `lmod` module files can be configured by editing the `modules.yaml` (described in  [iii. Updating location of module files](hpc-spack-setup.html#iii-updating-location-of-module-files) in [Setting Up Spack on HPC](hpc-spack-setup.html)). See the Spack documentation for more information on how to configure module files: https://spack.readthedocs.io/en/latest/module_file_support.html#.

--- a/_uw-research-computing/hpc-spack-setup.md
+++ b/_uw-research-computing/hpc-spack-setup.md
@@ -11,7 +11,7 @@ guide:
 
 CHTC uses Spack ([https://github.com/spack/spack](https://github.com/spack/spack)) for installing and managing software packages on the HPC cluster for all users to use, via the `module` command). Recently, Spack has developed a feature that allows for users to integrate their local installation of Spack with the system-wide installation. This means that when a user installs software with their local installation of Spack, they can automatically incorporate the system-wide packages to satisfy their software's dependencies (similar to Conda and Miniconda).
 
-**This guide describes how to set up a local copy of Spack and integrate it with the system installation, either for an individual user or for a group of users.** For instructions on how to install packages with Spack, see our other guide, [Installing Software Using Spack](hpc-spack-install.md).
+**This guide describes how to set up a local copy of Spack and integrate it with the system installation, either for an individual user or for a group of users.** For instructions on how to install packages with Spack, see our other guide, [Installing Software Using Spack](hpc-spack-install.html).
 
 > If your group has already set up a shared group installation of Spack, you can skip to the end of this guide: [3. Using a Shared Group Installation](#3-using-a-shared-group-installation).
 
@@ -93,7 +93,7 @@ spack find
 
 This should show a list of packages, including those you see when you run the `module avail` command. A total of ~120 packages should be listed.
 
-You are now ready to use Spack for installing the packages that you need! See the instructions in [Installing Software Using Spack](hpc-spack-install.md).
+You are now ready to use Spack for installing the packages that you need! See the instructions in [Installing Software Using Spack](hpc-spack-install.html).
 
 # 2. Setting Up Spack for Group Use
 
@@ -195,7 +195,7 @@ export SPACK_USER_CONFIG_PATH=/home/groups/yourGroupName/.spack
 
 ### iii. Updating location of module files
 
-If you or someone in your group is interested in creating custom modules following the instructions in the guide [Creating Custom Modules Using Spack](hpc-spack-modules.md), then you should update the location where the module files will be saved. You can update the location with the following commands
+If you or someone in your group is interested in creating custom modules following the instructions in the guide [Creating Custom Modules Using Spack](hpc-spack-modules.html), then you should update the location where the module files will be saved. You can update the location with the following commands
 
 ```
 spack config add 'modules:default:roots:lmod:/home/groups/yourGroupName/spack_modules'
@@ -205,13 +205,13 @@ spack config add 'modules:default:roots:tcl:/home/groups/yourGroupName/spack_mod
 
 where you replace `yourGroupName` with your group's name. 
 
-You are now ready to use Spack for installing the packages that you need! See the instructions in [Installing Software Using Spack](hpc-spack-install.md).
+You are now ready to use Spack for installing the packages that you need! See the instructions in [Installing Software Using Spack](hpc-spack-install.html).
 
 # 3. Using a Shared Group Installation
 
 **Users who want to use a shared group installation of Spack, but who did not set up the installation**, only need to modify their `~/.bash_profile` file with instructions regarding the path to the shared group installation and its configuration files.
 
-1. Log in to the HPC cluster ([Connecting to CHTC](connecting.md)).
+1. Log in to the HPC cluster ([Connecting to CHTC](connecting.html)).
    ```
    ssh yourNetID@hpclogin3.chtc.wisc.edu
    ```
@@ -249,7 +249,7 @@ You are now ready to use Spack for installing the packages that you need! See th
 
    or else close the terminal and log in again.
 
-Once configured, you can follow the instructions in our guide [Installing Software Using Spack](hpc-spack-install.md) to install or use already-installed packages in Spack.
+Once configured, you can follow the instructions in our guide [Installing Software Using Spack](hpc-spack-install.html) to install or use already-installed packages in Spack.
 
 ## A. Switching Between Spack Installations
 


### PR DESCRIPTION
Changed `.md` to `.html` for linked webpages.