### PR TITLE
Update conda-installation.md

### DIFF
--- a/_uw-research-computing/conda-installation.md
+++ b/_uw-research-computing/conda-installation.md
@@ -171,7 +171,7 @@ set the proper permissions for this file using `chmod`, and check the size of
 the final tarball: 
 
 ```
-(base)[alice@submit]$ conda pack -n env-name
+(base)[alice@submit]$ conda pack -n env-name --dest-prefix='$ENVDIR'
 (base)[alice@submit]$ chmod 644 env-name.tar.gz
 (base)[alice@submit]$ ls -sh env-name.tar.gz
 ```


### PR DESCRIPTION
Adding `--dest-prefix='$ENVDIR'` to the conda pack command. This fixes issues with conda hard-coding paths for R / R packages.