### PR TITLE
Explicitly list supported scopes for issuer

### DIFF
--- a/.well-known/openid-configuration
+++ b/.well-known/openid-configuration
@@ -9,6 +9,14 @@
       "client_secret_post",
       "client_secret_basic"
    ],
+   "scopes_supported":  [
+     "wlcg",
+     "storage.read:/",
+     "storage.write:/",
+     "org.cilogon.userinfo",
+     "openid",
+     "offline_access"
+   ],
    "grant_types_supported": [
       "refresh_token",
       "urn:ietf:params:oauth:grant-type:device_code"


### PR DESCRIPTION
Apparently, if supported scopes are completely missing, it causes `oidc-agent` to error out.