### PR TITLE
Correcting `int` partition limits

### DIFF
--- a/_uw-research-computing/hpc-job-submission.md
+++ b/_uw-research-computing/hpc-job-submission.md
@@ -112,10 +112,11 @@ If you want to run your job commands yourself, as a test before submitting
 a job as described above, you can request an interactive job on the cluster. 
 
 There is a dedicated partition 
-for interactive work called `int`; you may request up to a full node (128 CPUs, 
-512 GB RAM) when requesting an interactive session in the \"int\" partition and 
-the session is limited to 60 minutes. Using another partition (like `pre`) will 
-mean your interactive job is subject to the limits of that partition. 
+for interactive work called `int`; you may request up to 16 CPUS and 64GB of memory
+when requesting an interactive session in the \"int\" partition. By default,  
+the session is limited to 60 minutes though you can request up to 4 hours. 
+Using another partition (like `pre`) will 
+mean your interactive job is subject to the limits of that partition instead. 
 
 ### For simple testing or compiling
 

--- a/_uw-research-computing/hpc-overview.md
+++ b/_uw-research-computing/hpc-overview.md
@@ -78,7 +78,7 @@ backfill capacity via the `pre` partition (more details below).
   | Partition | p-name | \# nodes (N) | t-default | t-max | max cores/job | cores/node (n) | RAM/node (GB) |
   | --- |
   | Shared | shared | 45 | 1 day | 7 day | 320 | 64 or 128 | 512
-  | Interactive | int | 2 | 1 hr | 4 hrs | 320 | 16 | 64
+  | Interactive | int | 2 | 1 hr | 4 hrs | 16 | 64 or 128 | 512 (max 64 per job)
   | Pre-emptable (backfill) | pre | 45 | 4 hrs | 24 hrs | 320 | 64 or 128 | 512
   | Owners | *unique* | 19 | 24 hrs | 7 days | *unique* | 64 or 128 | 512
 

--- a/_uw-research-computing/hpc-overview.md
+++ b/_uw-research-computing/hpc-overview.md
@@ -78,7 +78,7 @@ backfill capacity via the `pre` partition (more details below).
   | Partition | p-name | \# nodes (N) | t-default | t-max | max cores/job | cores/node (n) | RAM/node (GB) |
   | --- |
   | Shared | shared | 45 | 1 day | 7 day | 320 | 64 or 128 | 512
-  | Interactive | int | 2 | 1 hr | 4 hrs | 320 | 64 or 128 | 512
+  | Interactive | int | 2 | 1 hr | 4 hrs | 320 | 16 | 64
   | Pre-emptable (backfill) | pre | 45 | 4 hrs | 24 hrs | 320 | 64 or 128 | 512
   | Owners | *unique* | 19 | 24 hrs | 7 days | *unique* | 64 or 128 | 512
 
@@ -88,7 +88,7 @@ Jobs submitted to this partition
 can request and use up to 7 days of running time.
 
 - `int` consists of two compute nodes is intended for short and immediate interactive 
-testing on a single node (up to 32 CPUs, 128 GB RAM). Jobs submitted to this partition 
+testing on a single node (up to 16 CPUs, 64 GB RAM). Jobs submitted to this partition 
 can run for up to 4 hours.
 
 - `pre` (i.e. pre-emptable) is an under-layed partition encompassing all HPC Cluster 


### PR DESCRIPTION
User tried to submit a 64 CPU interactive job and it never started, because `int` partition limits are much more strict than currently on the website. Updating website to reflect correct limits.