### PR TITLE
Account process details

### DIFF
--- a/_uw-research-computing/account-details.md
+++ b/_uw-research-computing/account-details.md
@@ -1,0 +1,60 @@
+---
+layout: guide
+title: How to Request a CHTC Account
+alt_title: How to Request a CHTC Account
+guide:
+    order: 2
+    category: Basics and Policies
+---
+
+# How to Request a CHTC Account
+
+The following sections detail the processes for requesting a new CHTC account, 
+or for continuing to use an existing CHTC account. Use of CHTC services are free 
+to use in support of University of Wisconsin - Madison’s research and teaching mission.
+
+## Current Member of UW - Madison
+
+If you are a current student, staff, or faculty at UW - Madison, you can request an account
+by completing the [Account Request Form](form.html). A staff member from CHTC will follow
+up with next steps. 
+
+All accounts require an active NetID and a faculty sponsor (typically the PI that is leading 
+your research project.)
+
+## Graduating from UW - Madison
+
+We understand that some users may need to continue carrying out their computational 
+analyses after graduation and the subsequent expiration of their NetID. 
+
+Once you are no longer enrolled in or employed by the University, you can continue
+to use your CHTC account as an "External Collaborator". Follow the instructions in
+the section below to have your faculty advisor sponsor your continued access to
+CHTC.
+
+**We highly recommend reaching out to CHTC staff before your NetID expires, if possible.**
+
+* Our policy is that CHTC accounts are deactivated and user data is erased after a user 
+is no longer actively using their account (~1 year of inactivity). It is your responsibility
+to maintain your data and important files in a location that is not CHTC's file systems.
+
+## External Collaborator
+
+If you are not a current member of UW - Madison, you can gain access to CHTC provided
+that you are sponsored by a faculty member of UW - Madison. To begin the account
+request process, have your Faculty Sponsor email CHTC (chtc@cs.wisc.edu) and provide:
+
+1. Your name,
+2. The reason you need (continued) access to CHTC resources,
+3. The amount of time they would like to sponsor your account,
+4. Your city/country of residence, and 
+5. Your institution. 
+
+CHTC staff will then follow up with next steps to create or extend your account. 
+
+* Your faculty sponsor can sponsor your account for up to one year at a time. If 
+you need continued access past one year, your faculty sponsor must contact us and 
+re-confirm that you should have continued access. 
+* Our policy is that CHTC accounts are deactivated and user data is erased after a user 
+is no longer actively using their account (~1 year of inactivity). It is your responsibility
+to maintain your data and important files in a location that is not CHTC's file systems.

--- a/_uw-research-computing/user-expectations.md
+++ b/_uw-research-computing/user-expectations.md
@@ -24,7 +24,8 @@ accounts for individuals or group-owned spaces for sharing files. Accounts that 
 notice being shared will be immediately disabled and a meeting with the PI 
 (faculty advisor) may be necessary to reinstate the account.
 
-For more information on access to CHTC after graduation, see [below](#access-chtc-resources-after-graduation).
+For more information on the process for obtaining an account, see our 
+[How to Request an Account](account-details.md) guide.
 
 ## Data Policies
 
@@ -92,28 +93,3 @@ in your user quota. Both our HTC and HPC systems use a fair shair policy and eac
 researcher has a user priority. **Submitting many jobs that fail or do not produce 
 the unexpected output will decrease your user priority without helping you complete 
 your research.**  User priorities naturally reset over time. 
-
-## Access CHTC Resources after Graduation
-
-We understand that some users may need to continue carrying out their computational 
-analyses after graduation and the subsequent expiration of their NetID. 
-
-To maintain access to CHTC resources after you leave your position at the University, 
-your faculty advisor can sponsor continued access to CHTC resources and your NetID. 
-Your Faculty Sponsor should email CHTC (chtc@cs.wisc.edu) and provide:
-
-1. Your name,
-1. The reason you need continued access to CHTC resources,
-1. The amount of time they would like to sponsor your account,
-1. Your new city/country of residence, and 
-1. Your new institution. 
-
-CHTC staff will then go through the needed steps to extend your account. 
-
-* We highly recommend reaching out to CHTC staff before your NetID expires, if possible. 
-* Your faculty sponsor can sponsor your account for up to one year at a time. If 
-you need continued access past one year, your faculty sponsor must contact us and 
-re-confirm that you should have continued access. 
-* As a reminder, CHTC accounts are deactivated and user data is erased after a user 
-is no longer actively using their account (~1 year of inactivity). It is your responsibility
-to maintain your data and important files in a location that is not CHTC's file systems. 


### PR DESCRIPTION
Moved the account-access-after-graduation section to a new page, and added other account request details to that page.