### PR TITLE
Link fixes Mar. 20

### DIFF
--- a/_data/uw-research-computing-menu.yml
+++ b/_data/uw-research-computing-menu.yml
@@ -9,6 +9,8 @@ nav_items:
     name: How To's
     url: /uw-research-computing/how-tos.html
     sub_menu:
+      - url: /uw-research-computing/account-details.html
+        name: Get an Account
       - url: /uw-research-computing/user-expectations.html
         name: User Expectations
       - url: /uw-research-computing/htc/guides.html

--- a/_uw-research-computing/form.html
+++ b/_uw-research-computing/form.html
@@ -14,6 +14,8 @@ is only mandatory for new groups to CHTC, but we strongly encourage anyone who
 is getting started to take advantage of this valuable opportunity to discuss your 
 work one-on-one with a CHTC Research Computing Facilitator. </p>
 
+<p>For more information, see [How to Request a CHTC Account](account-details.html)</p>
+
 <h2>Account Request Form</h2>
 
 <p>The following link leads to a Qualtrics form that we use for the account request process. </p>

--- a/_uw-research-computing/how-tos.html
+++ b/_uw-research-computing/how-tos.html
@@ -17,10 +17,13 @@ title: How To's
 <a href="{{ '/uw-research-computing/get-help.html' | relative_url }}">Get Help</a>
 </li>
 <li>
-<a href="{{ '/uw-research-computing/guides.html#htc-documentation' | relative_url }}">HTC Guides</a>
+<a href="{{ '/uw-research-computing/account-details.html' | relative_url }}">Get an Account</a>
 </li>
 <li>
-<a href="{{ '/uw-research-computing/guides.html#hpc-documentation' | relative_url }}">HPC Guides</a>
+<a href="{{ '/uw-research-computing/htc/guides.html' | relative_url }}">HTC Guides</a>
+</li>
+<li>
+<a href="{{ '/uw-research-computing/hpc/guides.html' | relative_url }}">HPC Guides</a>
 </li>
 <li>
 <a href="{{ '/uw-research-computing/cite-chtc.html' | relative_url }}">Cite CHTC Resources</a>

--- a/_uw-research-computing/hpc/guides.html
+++ b/_uw-research-computing/hpc/guides.html
@@ -20,7 +20,7 @@ Read through these user expectations and policies before using CHTC services.
 			<span class="navbar-toggler-icon"></span>
 		</button>
 		<div class="collapse navbar-collapse" id="navbarSupportedContent">
-			<a class="nav-link btn btn-primary text-white mb-2 mb-lg-0 w-100" aria-current="page" href="user-expectations.html">User Expectations</a>
+			<a class="nav-link btn btn-primary text-white mb-2 mb-lg-0 w-100" aria-current="page" href="{{ '/uw-research-computing/user-expectations.html' | relative_url }}">User Expectations</a>
 		</div>
 	</div>
 </nav>

--- a/_uw-research-computing/htc/guides.html
+++ b/_uw-research-computing/htc/guides.html
@@ -20,7 +20,7 @@ Read through these user expectations and policies before using CHTC services.
 			<span class="navbar-toggler-icon"></span>
 		</button>
 		<div class="collapse navbar-collapse" id="navbarSupportedContent">
-			<a class="nav-link btn btn-primary text-white mb-2 mb-lg-0 w-100" aria-current="page" href="user-expectations.html">User Expectations</a>
+			<a class="nav-link btn btn-primary text-white mb-2 mb-lg-0 w-100" aria-current="page" href="{{ '/uw-research-computing/user-expectations.html' | relative_url }}">User Expectations</a>
 		</div>
 	</div>
 </nav>


### PR DESCRIPTION
Preview should be at https://chtc.github.io/web-preview/preview-aowen-link-fix
Changes:
- Added (How to) "Get an Account" link to the How-To's dropdown menu
- Added "How to Get an Account" link to the How-To's webpage, Account Request Form page
- Corrected link to User Expectations in Guide pages
- Corrected links to Guide pages in How-To's webpage