### PR TITLE
Add public key for ap42.uw.osg-htc.org

### DIFF
--- a/.well-known/issuer.jwks
+++ b/.well-known/issuer.jwks
@@ -70,6 +70,15 @@
             "use": "sig",
             "x": "eDK50R6M81DUUWU9JIW9obA02U4sRZQSPR44pcFnkSI=",
             "y": "P8-SthnBHG5iwfSA1meV5ZV4tvobD4_6Mb_cPgiC9JA="
+        },
+        {
+            "alg": "ES256",
+            "crv": "P-256",
+            "kid": "0889",
+            "kty": "EC",
+            "use": "sig",
+            "x": "3_cLC0JcJX5W1E5zI5Hde2Gt6I6jGU0SnbBJbAFx0wo=",
+            "y": "0YlUfPgcWMljt0gKspjxhAkijIAJ7fTmTQkxFGVswL0="
         }
     ]
 }


### PR DESCRIPTION
Otherwise known as ospool-ap42.chtc.wisc.edu; done in support of INF-1709: Provision dedicated IGWN OSPool AP https://opensciencegrid.atlassian.net/browse/INF-1709

Done with instructions from the CHTC Wiki [here](https://wiki.chtc.wisc.edu/wiki/Create_SciToken_Key_Pair_for_Credmon#CHTC_Pool).