### PR TITLE
Replacing references to squid with staging

### DIFF
--- a/_uw-research-computing/conda-installation.md
+++ b/_uw-research-computing/conda-installation.md
@@ -185,12 +185,11 @@ When this step finishes, you should see a file in your current directory named
 The tar archive, `env-name.tar.gz`, created in the previous step will be used as input for 
 subsequent job submission. As with all job input files, you should check the size of this 
 Conda environment file. **If >100MB in size, you should NOT transfer the tar ball using 
-`transfer_input_files`**. Instead, you should plan to use either CHTC's web proxy, SQUID or 
+`transfer_input_files`**. Instead, you should plan to use the 
 large data filesystem Staging. Please contact a research computing facilitators at 
 chtc@cs.wisc.edu to determine the best option for your jobs. 
 
-More information is available at [File Availability with Squid Web Proxy](file-avail-squid.html) 
-and [Managing Large Data in HTC Jobs](file-avail-largedata.html).
+More information is available at [Managing Large Data in HTC Jobs](file-avail-largedata.html).
 
 ## 5. Create a Job Executable
 
@@ -229,9 +228,8 @@ In your submit file, make sure to have the following:
 - Remember to transfer your Python script and the environment `tar.gz` file via
  `transfer_input_files`. 
   **Since the `tar.gz` file will almost certainly be larger than 100MB, 
-  please [email](mailto:chtc@cs.wisc.edu) us about different tools for 
-  delivering the installation to your jobs, 
-  likely our [SQUID web proxy](file-avail-squid.html).**
+  please place it in your `/staging` directory and use the instructions in 
+  (file-avail-largedata.html) to transfer the `tar.gz` file instead.**
 
 <!--
 # Option 2: Install Miniconda Inside Each Job

--- a/_uw-research-computing/docker-jobs.md
+++ b/_uw-research-computing/docker-jobs.md
@@ -18,7 +18,7 @@ submit jobs that use Docker containers.
 
 Typically, software in CHTC jobs is installed or compiled locally by
 individual users and then brought along to each job, either using the
-default file transfer or our SQUID web server. However, another option
+default file transfer or the staging system. However, another option
 is to use a *container* system, where the software is installed in a
 *container image*. Using a container to handle software can be
 advantageous if the software installation 1) has many dependencies, 2)

--- a/_uw-research-computing/htc-modules.md
+++ b/_uw-research-computing/htc-modules.md
@@ -241,7 +241,7 @@ interactive job will be copied back to the submit location for you.
 If your MPI program is especially large (more than 100 MB, compiled), or
 if it can *only* run from the exact location to which it was installed,
 you may also need to take advantage of CHTC\'s shared software location
-or our public web proxy called Squid. Email CHTC\'s Research Computing
+or large data staging system. Email CHTC\'s Research Computing
 Facilitators at [chtc@cs.wisc.edu](mailto:chtc@cs.wisc.edu) if this is the case.
 
 

--- a/_uw-research-computing/julia-jobs.md
+++ b/_uw-research-computing/julia-jobs.md
@@ -212,9 +212,9 @@ After the job exits, you will be returned to your `/home` directory on the
 submit server (specifically where ever you were located when you submitted 
 the interactive build job). A copy of `packages.tar.gz` will be present. **Be 
 sure to check the size of the project tarball before proceeding to subsequent job 
-submissions.** If the file is >100MB please contact us at <chtc@cs.wisc.edu> so 
-that we can get you setup with access to our SQUID web proxy. More details 
-are available on our SQUID guide: [File Availability with SQUID](file-avail-squid.html)
+submissions.** If the file is >100MB please use your staging directory instead. 
+More details are available in our large data staging guide: 
+[Use Large Input and Output Files Via Staging](file-avail-largedata.html)
 
 ```
 [alice@submit]$ ls 
@@ -320,8 +320,8 @@ For project tar.gz files that are <100MB, you can follow the below example:
 transfer_input_files = julia-#.#.#-linux-x86_64.tar.gz, script.jl, my-project.tar.gz
 ```
 
-For project tar.gz files that are larger than 100MB, email a facilitator about 
-using SQUID.  
+For project tar.gz files that are larger than 100MB, use your `/staging` directory.
+For more information, see our [guide on staging large data](file-avail-largedata.html).
 
 Modify the CPU/memory request lines to match what is needed by the job. 
 Test a few jobs for disk space/memory usage in order to make sure your 

--- a/_uw-research-computing/r-build.md
+++ b/_uw-research-computing/r-build.md
@@ -4,6 +4,8 @@ layout: guide
 title: Building R in HTC
 ---
 
+**This guide is deprecated. Please follow the instructions [here](software-overview-htc.html#r) instead.**
+
 # Overview
 
 **This guide will provide instructions for compiling base R from source code and is intended 

--- a/_uw-research-computing/scaling-htc.md
+++ b/_uw-research-computing/scaling-htc.md
@@ -74,7 +74,7 @@ to us, they have two major requirements:
 
 -   **Moderate Data Sizes**: We can support input file sizes of up to 
 	20 GB per file per job. This covers input files that would normally be 
-	transferred out of a `/home` directory or use SQUID, in addition to larger 
+	transferred out of a `/home` directory or use staging, in addition to larger 
 	files up to 20GB. Outputs per job can be of similar sizes. If your input or 
 	output files are larger than 1GB, or you have any other questions about 
 	handling data on resources beyond CHTC, please [contact us](mailto:chtc@cs.wisc.edu)! 

--- a/_uw-research-computing/tensorflow-singularity-wait.md
+++ b/_uw-research-computing/tensorflow-singularity-wait.md
@@ -13,7 +13,7 @@ Overview
 
 Typically, software in CHTC jobs is installed or compiled locally by
 individual users and then brought along to each job, either using the
-default file transfer or our SQUID web server. However, another option
+default file transfer or our staging system. However, another option
 is to use a *container* system, where the software is installed in a
 *container image*. CHTC (and the OS Pool) have capabilities to access and
 start containers and run jobs inside them. One container option


### PR DESCRIPTION
Tired of people asking for squid. I've removed references to squid from the various software guides and replaced with references to staging. But I've left the `file-avail` guides untouched. 