### PR TITLE
Replace hpclogin3 refs

### DIFF
--- a/_uw-research-computing/connecting.md
+++ b/_uw-research-computing/connecting.md
@@ -49,8 +49,8 @@ servers or head nodes:
   {:.gtable}
   | HPC Cluster |
   | --- |
-  | `hpclogin3.chtc.wisc.edu`
-  | `hpclogin1.chtc.wisc.edu` and/or `hpclogin2.chtc.wisc.edu` - access the old HPC cluster until February 28, 2023 |
+  | `spark-login.chtc.wisc.edu`
+  | `hpclogin3.chtc.wisc.edu` - access the old HPC cluster, slated to be decommissioned |
 
 As of December 2022, we also require two-factor authentication with Duo to 
 access CHTC resources. 

--- a/_uw-research-computing/hpc-job-submission.md
+++ b/_uw-research-computing/hpc-job-submission.md
@@ -21,7 +21,7 @@ Contents
 1. [Removing or Holding Jobs](#4-removing-or-holding-jobs)
 
 The following assumes that you have been granted access to the HPC cluster 
-and can log into the head node `hpclogin3.chtc.wisc.edu`. If this is not
+and can log into the head node `spark-login.chtc.wisc.edu`. If this is not
 the case, please see the [CHTC account application page](form.html) or email
 the facilitation team at chtc@cs.wisc.edu. 
 

--- a/_uw-research-computing/hpc-overview.md
+++ b/_uw-research-computing/hpc-overview.md
@@ -61,7 +61,7 @@ To see more details of other software on the cluster, see the [HPC Software page
 
 ## Login Nodes
 
-The login node for the cluster is: `hpclogin3.chtc.wisc.edu` 
+The login node for the cluster is: `spark-login.chtc.wisc.edu` 
 
 For more details on logging in, see the "Connecting to CHTC" guide linked above. 
 

--- a/_uw-research-computing/hpc-spack-setup.md
+++ b/_uw-research-computing/hpc-spack-setup.md
@@ -213,7 +213,7 @@ You are now ready to use Spack for installing the packages that you need! See th
 
 1. Log in to the HPC cluster ([Connecting to CHTC](connecting.html)).
    ```
-   ssh yourNetID@hpclogin3.chtc.wisc.edu
+   ssh yourNetID@spark-login.chtc.wisc.edu
    ```
    {:.term}
 


### PR DESCRIPTION
Replace references to hpclogin3 in the guides to spark-login.