### PR TITLE
Add buttons to request an account/quota

### DIFF
--- a/_uw-research-computing/get-help.md
+++ b/_uw-research-computing/get-help.md
@@ -10,15 +10,27 @@ See below for the various ways to get help when using CHTC services.
 
 ## Get An Account
 
-If you don't have an account yet, please fill out our [Request
-Form](form.html), and we'll follow up with your account details 
-or a request to meet. If you don't have an account but just have general
-questions, feel free to send an email to chtc@cs.wisc.edu (see below).
+If you don't have an account yet, please fill out our request form, and we'll
+follow up with your account details or a request to meet. If you don't have an
+account but just have general questions, feel free to send an email to
+[chtc@cs.wisc.edu](Mailto:chtc@cs.wisc.edu).
+
+<div class="d-flex mb-3">
+	<div class="p-3 m-auto">
+		<a class="btn btn-primary" href="https://uwmadison.co1.qualtrics.com/jfe/form/SV_8f6nTgaaVhefdmS">Request a CHTC Account</a>
+	</div>
+</div>
 
 ## Request a Quota Change
 
 If you'd like to request a change in your quotas for one of our data
 storage locations, please see our [Request a Quota Change](quota-request) guide.
+
+<div class="d-flex mb-3">
+	<div class="p-3 m-auto">
+		<a class="btn btn-primary" href="quota-request">Request a Quota Change</a>
+	</div>
+</div>
 
 ## Help Via Email
 

--- a/_uw-research-computing/get-help.md
+++ b/_uw-research-computing/get-help.md
@@ -39,7 +39,7 @@ expect a first response within 1-2 business days.
 
 <div class="d-flex mb-3">
 	<div class="p-3 m-auto">
-		<a class="btn btn-primary" href="mailto:chtc@cs.wisc.edu">Email us</a>
+		<a class="btn btn-primary" href="mailto:chtc@cs.wisc.edu">chtc@cs.wisc.edu</a>
 	</div>
 </div>
 

--- a/_uw-research-computing/get-help.md
+++ b/_uw-research-computing/get-help.md
@@ -34,19 +34,23 @@ storage locations, please see our [Request a Quota Change](quota-request) guide.
 
 ## Help Via Email
 
-We provide support via email at the address
-[chtc@cs.wisc.edu](Mailto:chtc@cs.wisc.edu) and this is a good, 
-general way to reach us. You can typically
+We provide general support via email at [chtc@cs.wisc.edu](mailto:chtc@cs.wisc.edu). You can typically
 expect a first response within 1-2 business days. 
 
-When emailing us for assistance in troubleshooting an issue, please provide which system you are using, 
-an explanation of what you expected to happen versus what actually happened, and  
-include relevant files (or provide the locations of them on the system), such as:
+<div class="d-flex mb-3">
+	<div class="p-3 m-auto">
+		<a class="btn btn-primary" href="mailto:chtc@cs.wisc.edu">Email us</a>
+	</div>
+</div>
 
-* The job submit file (.sub)
-* The job executable (.sh) or list of commands used in an interactive job
-* Standard error and standard output files (usually .out or .err)
-* If on the HTC system, the HTCondor log file (.log)
+When emailing us for assistance in troubleshooting an issue, please provide which system you are using, 
+an explanation of what you expected to happen versus what actually happened, and include relevant files
+(or provide the locations of them on the system), such as:
+
+* The job submit file (`.sub`)
+* The job executable (`.sh`) or list of commands used in an interactive job
+* Standard error and standard output files (usually `.out` or `.err`)
+* If on the HTC system, the HTCondor log file (`.log`)
 
 We will use this information to give you more effective responses and solutions.
 
@@ -76,7 +80,11 @@ login message when you log into a CHTC server.
 As always, if the times above don't work for you, please email us 
 at our usual support address to schedule a separate meeting. 
 
-[Click to sign-in for office hours](sign-in.html)
+<div class="d-flex mb-3">
+	<div class="p-3 m-auto">
+		<a class="btn btn-primary" href="sign-in.html">Sign-in for office hours</a>
+	</div>
+</div>
 
 ### CHTC Events and Office Hours Calendar
 <iframe id="open-web-calendar" 
@@ -88,14 +96,18 @@ at our usual support address to schedule a separate meeting.
 
 ## Check System Status
 
-We have a system status page at [https://status.chtc.wisc.edu](https://status.chtc.wisc.edu) that we 
-use to provide updates 
-about CHTC system issues, including outages and scheduled maintenance. Major outages and maintenance 
-issues are still communicated via the `chtc-users` email list, but minor issues and updates to 
+Check our system status page at [https://status.chtc.wisc.edu](https://status.chtc.wisc.edu), where we 
+provide updates  about CHTC system issues, including outages and scheduled maintenance. Major outages and maintenance  issues are still communicated via the `chtc-users` email list, but minor issues and updates to 
 ongoing issues will be communicated via the status page. 
 
-* If you are experiencing an issue with the system, please check the status page! If you 
-don't see a corresponding incident, feel free to email us.
+> If you are experiencing an issue with the system, please check the status page! If you 
+> don't see a corresponding incident, feel free to email us.
+
+<div class="d-flex mb-3">
+	<div class="p-3 m-auto">
+		<a class="btn btn-primary" href="https://status.chtc.wisc.edu">Check System Status</a>
+	</div>
+</div>
 
 ## Make an Appointment
 


### PR DESCRIPTION
Added buttons for requesting an account / requesting more quota.

Note that the quota button does not lead to the Qualtric form, but it goes to the request quota page instead to encourage users to review data policies before submitting the form.