### PR TITLE
Preview xalim login

### DIFF
--- a/_uw-research-computing/basic-shell-commands.md
+++ b/_uw-research-computing/basic-shell-commands.md
@@ -11,8 +11,8 @@ guide:
         - hpc
 ---
 
-# Introduction
-<br>
+## Introduction
+
 This page contains quick references for basic shell commands and links to more detailed resources. Users need to know basic shell commands to navigate directories and modify files for use on CHTC systems. Users can reference this page to gain familiarity or refresh their knowledge of shell commands.
 
 {% capture content %}
@@ -23,8 +23,8 @@ This page contains quick references for basic shell commands and links to more d
 {% endcapture %}
 {% include /components/directory.html title="Table of Contents" %}
 
-# Learn about the command line
-## Why should you learn about the command line?
+## Learn about the command line
+### Why should you learn about the command line?
 
 If you haven't used the command line before, it might seem like a big challenge to get started. However, we strongly recommend learning more about the command line for multiple reasons:
 
@@ -32,20 +32,23 @@ If you haven't used the command line before, it might seem like a big challenge 
 * With practice, typing on the command line is significantly faster and much more powerful than using a point-and-click graphic interface.
 * Command line skills are useful for more than just large-scale computing.
 
-## Get started with the command line
+> ## For beginning users: Get started with the command line
+{:.tip-header}
 
-For a good overview of command line tools, see the [Software Carpentry Unix Shell](http://swcarpentry.github.io/shell-novice/) lesson. We recommend the sections on:
+> For a good overview of command line tools, see the [Software Carpentry Unix Shell](http://swcarpentry.github.io/shell-novice/) lesson. We recommend that you learn how to:
+> 
+> -   [understand the filesystem and how to navigate it](https://swcarpentry.github.io/shell-novice/02-filedir.html)
+> -   [use tab-completion](https://swcarpentry.github.io/shell-novice/02-filedir.html#nelles-pipeline-organizing-files)
+> -   [create files](https://swcarpentry.github.io/shell-novice/03-create.html)
+> -   [use the star wildcard](https://swcarpentry.github.io/shell-novice/04-pipefilter.html)
+> -   [write shell scripts](https://swcarpentry.github.io/shell-novice/06-script.html)
+{:.tip}
 
--   understand the filesystem and how to navigate it ([Navigating Files and Directories](https://swcarpentry.github.io/shell-novice/02-filedir.html))
--   tab-completion (section entitled "Nelle's Pipeline, Organizing Files", in [Navigating Files and Directories](https://swcarpentry.github.io/shell-novice/02-filedir.html))
--   creating files ([Working With Files and Directories](https://swcarpentry.github.io/shell-novice/03-create.html))
--   using the star wildcard (first part of [Pipes and Filters](https://swcarpentry.github.io/shell-novice/04-pipefilter.html))
--   writing shell scripts ([Shell Scripts](https://swcarpentry.github.io/shell-novice/06-script.html))
 
+## Quick reference: basic shell commands
+Note: Bracketed items (`<>`) denote where to place your input. *Do not* include the brackets in your command.
 
-# Quick reference: basic shell commands
-
-## Navigate directories
+### Navigate directories
 
 | Command | Use | Notes |
 | --- | --- | --- |
@@ -53,12 +56,12 @@ For a good overview of command line tools, see the [Software Carpentry Unix Shel
 | | | `..` - one level above the current directory |
 | | | `~` - your home directory (`/home/username/`) |
 | `pwd` | prints path of the working (current) directory |
-| `ls` | lists files in current directory| `-lh` prints human-readable information |
-| | | `-a` prints hidden files |
+| `ls <directory>` | lists files in `directory` | `-lh` prints human-readable information |
+| `ls` | list files in current directory | `-a` prints hidden files |
 | `mkdir <directory>` | creates a directory |
 | `rmdir <directory>` | removes a directory (must be empty) |
 
-## Inspect files
+### Inspect files
 
 | Command | Use |
 | --- | --- |
@@ -68,14 +71,14 @@ For a good overview of command line tools, see the [Software Carpentry Unix Shel
 | `tail <file>` | prints the last ten lines of `file` |
 | `grep <phrase> <file>` | grabs and prints every instance of `phrase` in `file` |
 
-## Edit files
+### Edit files
 
 | Command | Use | Notes |
 | --- | --- | --- |
 | `nano <file>` | opens or creates `file` in the `nano` text editor | [cheatsheet for nano commands](https://www.nano-editor.org/dist/latest/cheatsheet.html) |
 | `vim <file>` or `vi <file>` | opens or creates `file` in the `vim` text editor | [cheatsheet for vim commands](https://vimsheet.com/) |
 
-## Copy, move, and remove files
+### Copy, move, and remove files
 
 | Command | Use |
 | --- | --- |
@@ -84,7 +87,7 @@ For a good overview of command line tools, see the [Software Carpentry Unix Shel
 | `rm <file1>` | removes `file1` |
 | `scp <file> <destination>` | moves files between machines. See how to [transfer files to/from your local computer](transfer-files-computer) |
 
-## Wildcards
+### Wildcards
 
 | Wildcard | Use | Notes |
 | --- | --- | --- |
@@ -93,15 +96,15 @@ For a good overview of command line tools, see the [Software Carpentry Unix Shel
 
 [Read more](https://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm) about wildcards.
 
-## Other commands
+### Other commands
 
 | Commmand | Use | Notes |
 | --- | --- | --- |
 | `echo <$var>` | prints the value of `$var` | Example: `echo $PWD` returns the current directory |
 | `chmod +x` | adds executable permissions to a file |
 
-# Related pages
-<br>
+## Related pages
+
 Below are more resources for learning the basic shell commands and the command line.
 
 * [Software Carpentry Unix Shell](http://swcarpentry.github.io/shell-novice/) lessons

--- a/_uw-research-computing/basic-shell-commands.md
+++ b/_uw-research-computing/basic-shell-commands.md
@@ -12,79 +12,97 @@ guide:
 ---
 
 # Introduction
-
-
+<br>
+This page contains quick references for basic shell commands and links to more detailed resources. Users need to know basic shell commands to navigate directories and modify files for use on CHTC systems. Users can reference this page to gain familiarity or refresh their knowledge of shell commands.
 
 {% capture content %}
-
+- [Introduction](#introduction)
+- [Learn about the command line](#learn-about-the-command-line)
+- [Quick reference: basic shell commands](#quick-reference-basic-shell-commands)
+- [Related pages](#related-pages)
 {% endcapture %}
 {% include /components/directory.html title="Table of Contents" %}
 
-# Basic shell commands (quick reference)
+# Learn about the command line
+## Why should you learn about the command line?
+
+If you haven't used the command line before, it might seem like a big challenge to get started. However, we strongly recommend learning more about the command line for multiple reasons:
+
+* Only a few basic commands are needed to successfully submit jobs on CHTC.
+* With practice, typing on the command line is significantly faster and much more powerful than using a point-and-click graphic interface.
+* Command line skills are useful for more than just large-scale computing.
+
+## Get started with the command line
+
+For a good overview of command line tools, see the [Software Carpentry Unix Shell](http://swcarpentry.github.io/shell-novice/) lesson. We recommend the sections on:
+
+-   understand the filesystem and how to navigate it ([Navigating Files and Directories](https://swcarpentry.github.io/shell-novice/02-filedir.html))
+-   tab-completion (section entitled "Nelle's Pipeline, Organizing Files", in [Navigating Files and Directories](https://swcarpentry.github.io/shell-novice/02-filedir.html))
+-   creating files ([Working With Files and Directories](https://swcarpentry.github.io/shell-novice/03-create.html))
+-   using the star wildcard (first part of [Pipes and Filters](https://swcarpentry.github.io/shell-novice/04-pipefilter.html))
+-   writing shell scripts ([Shell Scripts](https://swcarpentry.github.io/shell-novice/06-script.html))
+
+
+# Quick reference: basic shell commands
 
 ## Navigate directories
 
 | Command | Use | Notes |
 | --- | --- | --- |
-| `cd <directory>` | change current directory to `directory` | `.` - the current directory |
+| `cd <path/to/directory>` | changes current directory to `path/to/directory` | `.` - the current directory |
 | | | `..` - one level above the current directory |
 | | | `~` - your home directory (`/home/username/`) |
 | `pwd` | prints path of the working (current) directory |
-| `ls` | list files in current directory| `-lh` prints human-readable information |
+| `ls` | lists files in current directory| `-lh` prints human-readable information |
 | | | `-a` prints hidden files |
 | `mkdir <directory>` | creates a directory |
 | `rmdir <directory>` | removes a directory (must be empty) |
 
 ## Inspect files
 
-| Command | Use | Notes |
+| Command | Use |
+| --- | --- |
 | `cat <file>` | prints contents of `file` |
+| `less <file>` | views contents of `file` (similar to `vim`, but without edit capabilities) |
 | `head <file>` | prints the first ten lines of `file` |
 | `tail <file>` | prints the last ten lines of `file` |
 | `grep <phrase> <file>` | grabs and prints every instance of `phrase` in `file` |
 
 ## Edit files
 
-| Command | Use |
-| `nano <file>` | opens or creates `file` in the `nano` text editor |
-| `vim <file>` | opens or creates `file` in the `vim` text editor |
+| Command | Use | Notes |
+| --- | --- | --- |
+| `nano <file>` | opens or creates `file` in the `nano` text editor | [cheatsheet for nano commands](https://www.nano-editor.org/dist/latest/cheatsheet.html) |
+| `vim <file>` or `vi <file>` | opens or creates `file` in the `vim` text editor | [cheatsheet for vim commands](https://vimsheet.com/) |
 
 ## Copy, move, and remove files
 
 | Command | Use |
+| --- | --- |
 | `cp <file1> <file2>` | copies `file1` to `file2` |
 | `mv <file1> <file2>` | moves or renames `file1` to `file2` |
 | `rm <file1>` | removes `file1` |
+| `scp <file> <destination>` | moves files between machines. See how to [transfer files to/from your local computer](transfer-files-computer) |
 
-# Learn about the command line
+## Wildcards
 
-**Why learn about the command line?** If you haven\'t used the command
-line before, it might seem like a big challenge to get started, and
-easier to use other tools, especially if you have a Windows computer.
-However, we strongly recommend learning more about the command line for
-multiple reasons:
+| Wildcard | Use | Notes |
+| --- | --- | --- |
+| `?` | matching any character | Example: `rm ?.txt` removes `1.txt` and `b.txt` but not `24.txt` | 
+| `*` | matching any characters of any length | Example: `rm *.txt` removes all files with the `.txt` extension |
 
--   You can do most of what you need to do in CHTC by learning a few
-    basic commands.
--   With a little practice, typing on the command line is significantly
-    faster and much more powerful than using a point-and-click graphic
-    interface.
--   Command line skills are useful for more than just large-scale
-    computing.
+[Read more](https://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm) about wildcards.
 
-For a good overview of command line tools, see the [Software Carpentry
-Unix Shell](http://swcarpentry.github.io/shell-novice/) lesson. In
-particular, we recommend the sections on:
+## Other commands
 
--   understanding the filesystem and how to navigate it ([Navigating
-    Files and Directories](https://swcarpentry.github.io/shell-novice/02-filedir.html))
--   tab-completion (section entitled \"Nelle\'s Pipeline, Organizing
-    Files\", in [Navigating Files and
-    Directories](https://swcarpentry.github.io/shell-novice/02-filedir.html))
--   creating files ([Working With Files and
-    Directories](https://swcarpentry.github.io/shell-novice/03-create.html))
--   using the star wildcard (first part of [Pipes and
-    Filters](https://swcarpentry.github.io/shell-novice/04-pipefilter.html))
--   writing shell scripts ([Shell
-    Scripts](https://swcarpentry.github.io/shell-novice/06-script.html))
+| Commmand | Use | Notes |
+| --- | --- | --- |
+| `echo <$var>` | prints the value of `$var` | Example: `echo $PWD` returns the current directory |
+| `chmod +x` | adds executable permissions to a file |
 
+# Related pages
+<br>
+Below are more resources for learning the basic shell commands and the command line.
+
+* [Software Carpentry Unix Shell](http://swcarpentry.github.io/shell-novice/) lessons
+* [Ubuntu tutorial: The Linux command line for beginners](https://ubuntu.com/tutorials/command-line-for-beginners#1-overview)

--- a/_uw-research-computing/basic-shell-commands.md
+++ b/_uw-research-computing/basic-shell-commands.md
@@ -1,0 +1,90 @@
+---
+highlighter: none
+layout: guide
+title: Basic shell commands
+alt_title: Basic shell commands
+guide:
+    order: 4
+    category: Basics and Policies
+    tag:
+        - htc
+        - hpc
+---
+
+# Introduction
+
+
+
+{% capture content %}
+
+{% endcapture %}
+{% include /components/directory.html title="Table of Contents" %}
+
+# Basic shell commands (quick reference)
+
+## Navigate directories
+
+| Command | Use | Notes |
+| --- | --- | --- |
+| `cd <directory>` | change current directory to `directory` | `.` - the current directory |
+| | | `..` - one level above the current directory |
+| | | `~` - your home directory (`/home/username/`) |
+| `pwd` | prints path of the working (current) directory |
+| `ls` | list files in current directory| `-lh` prints human-readable information |
+| | | `-a` prints hidden files |
+| `mkdir <directory>` | creates a directory |
+| `rmdir <directory>` | removes a directory (must be empty) |
+
+## Inspect files
+
+| Command | Use | Notes |
+| `cat <file>` | prints contents of `file` |
+| `head <file>` | prints the first ten lines of `file` |
+| `tail <file>` | prints the last ten lines of `file` |
+| `grep <phrase> <file>` | grabs and prints every instance of `phrase` in `file` |
+
+## Edit files
+
+| Command | Use |
+| `nano <file>` | opens or creates `file` in the `nano` text editor |
+| `vim <file>` | opens or creates `file` in the `vim` text editor |
+
+## Copy, move, and remove files
+
+| Command | Use |
+| `cp <file1> <file2>` | copies `file1` to `file2` |
+| `mv <file1> <file2>` | moves or renames `file1` to `file2` |
+| `rm <file1>` | removes `file1` |
+
+# Learn about the command line
+
+**Why learn about the command line?** If you haven\'t used the command
+line before, it might seem like a big challenge to get started, and
+easier to use other tools, especially if you have a Windows computer.
+However, we strongly recommend learning more about the command line for
+multiple reasons:
+
+-   You can do most of what you need to do in CHTC by learning a few
+    basic commands.
+-   With a little practice, typing on the command line is significantly
+    faster and much more powerful than using a point-and-click graphic
+    interface.
+-   Command line skills are useful for more than just large-scale
+    computing.
+
+For a good overview of command line tools, see the [Software Carpentry
+Unix Shell](http://swcarpentry.github.io/shell-novice/) lesson. In
+particular, we recommend the sections on:
+
+-   understanding the filesystem and how to navigate it ([Navigating
+    Files and Directories](https://swcarpentry.github.io/shell-novice/02-filedir.html))
+-   tab-completion (section entitled \"Nelle\'s Pipeline, Organizing
+    Files\", in [Navigating Files and
+    Directories](https://swcarpentry.github.io/shell-novice/02-filedir.html))
+-   creating files ([Working With Files and
+    Directories](https://swcarpentry.github.io/shell-novice/03-create.html))
+-   using the star wildcard (first part of [Pipes and
+    Filters](https://swcarpentry.github.io/shell-novice/04-pipefilter.html))
+-   writing shell scripts ([Shell
+    Scripts](https://swcarpentry.github.io/shell-novice/06-script.html))
+

--- a/_uw-research-computing/configure-ssh.md
+++ b/_uw-research-computing/configure-ssh.md
@@ -10,22 +10,10 @@ guide:
 ---
 
 This guide describes 
-* how to authenticate with Duo when logging into CHTC's HTC and HPC systems
 * how to set your login (SSH) configuration to “reuse” a two-factor authenticated 
 connection over a certain period of time. 
 * terminals and applications that are known to support persistent connections
 
-## Authentication with Duo
-
-As of December 2022, accessing CHTC resources 
-now requires two-factor authentication. The first “factor” uses your NetID password 
-(or SSH keys) and the second “factor” is authentication using Duo, via either a 
-Duo fob or the Duo app. 
-
-See the following video for an demonstration of two-factor authentication with Duo 
-when logging into CHTC: 
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/J-wxsrQ3v04" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Re-Using SSH Connections
 
@@ -49,6 +37,7 @@ The instructions below are meant for users who can use a terminal (Mac, Linux, n
 1. Create (or edit) your personal SSH configuration file at `~/.ssh/config` to use 
 what’s called "ControlMaster"
 This is the text that should be added to a file called `config` in the `.ssh` directory in your computer's home directory: 
+
 	```	
 	Host *.chtc.wisc.edu
 	  # Turn ControlMaster on
@@ -82,7 +71,7 @@ This is the text that should be added to a file called `config` in the `.ssh` di
 1. You also create a directory that will be used to track connections. In 
 the same .ssh directory, make a folder called `connections` by typing: 
 	```
-	$ mkdir -p ~/.ssh/connections
+	mkdir -p ~/.ssh/connections
 	```
 	{: .term}
 	

--- a/_uw-research-computing/configure-ssh.md
+++ b/_uw-research-computing/configure-ssh.md
@@ -1,6 +1,6 @@
 ---
 layout: guide
-title: Automate CHTC Log In
+title: Automate CHTC login
 guide:
     order: 4
     category: Basics and Policies
@@ -9,34 +9,40 @@ guide:
         - hpc
 ---
 
-This guide describes 
-* how to set your login (SSH) configuration to “reuse” a two-factor authenticated 
-connection over a certain period of time. 
-* terminals and applications that are known to support persistent connections
+## Introduction
 
+This guide describes how to set your login (SSH) configuration to reuse an authenticated connection over a certain period of time, also known as a persistent connection. Terminals and applications that are known to support persistent connections are also listed on this page.
 
-## Re-Using SSH Connections
+{% capture content %}
+- [Introduction](#introduction)
+- [Reuse SSH connections to reduce login frequency](#reuse-ssh-connections-to-reduce-login-frequency)
+- [End hanging or stuck connections](#end-hanging-or-stuck-connections)
+- [Port forwarding](#port-forwarding)
+- [Enable persistent connections in other programs](#enable-persistent-connections-in-other-programs)
+   * [WinSCP](#winscp)
+   * [Cyberduck](#cyberduck)
+   * [Unsupported programs](#unsupported-programs)
+- [Other Tools](#other-tools)
+- [Summary](#summary)
+- [Related pages](#related-pages)
+{% endcapture %}
+{% include /components/directory.html title="Table of Contents" %}
 
-To reduce the number of times it is necessary to enter your credentials, it’s possible 
-to customize your SSH configuration in a way that allows you to “reuse” a connection 
-for logging in again or moving files.  This configuration is optional, and 
-most useful if you will connect to 
-the same server multiple times in a short window, for example, when uploading or 
-downloading files. 
+## Reuse SSH connections to reduce login frequency
 
-**WARNING:** This guide describes how to configure your local machine to not require 
-reentering your NetID password or Duo authentication each time you login. 
-This should **ONLY** be used on secure devices that you manage - **it should 
-not be used on any shared laptop, desktop, or research group resource. Users 
-found violating this policy risk having their CHTC account permanently deactivated.** 
+In this optional configuration, you can reuse an SSH connection to reduce the number of times you need to re-enter your credentials and authenticate with Duo MFA. This can be useful when connecting to the same server multiple times within a short period of time, for example, when uploading or downloading files. 
 
-The instructions below are meant for users who can use a terminal (Mac, Linux, newer Windows operating systems): 
+> ### ⚠️ Caution!
+{:.tip-header}
+
+> This guide should ***ONLY*** be used on secure devices that you manage. It should ***not*** be used on any shared laptop, desktop, or research group resource. **Users found violating this policy risk having their CHTC account permanently deactivated.** 
+{:.tip}
+
+### Configure SSH to reuse connections
 
 1. Open a terminal window.
 
-1. Create (or edit) your personal SSH configuration file at `~/.ssh/config` to use 
-what’s called "ControlMaster"
-This is the text that should be added to a file called `config` in the `.ssh` directory in your computer's home directory: 
+1. Create (or edit) your personal SSH configuration file at `~/.ssh/config`. The configuration file is a text-based file. Within this file, we will enable some "ControlMaster" options. 
 
 	```	
 	Host *.chtc.wisc.edu
@@ -50,8 +56,9 @@ This is the text that should be added to a file called `config` in the `.ssh` di
 	  # the ControlMaster persistent connections
 	  ControlPath ~/.ssh/connections/%r@%h:%p
 	```
-	If you're not able to find or create the config file, executing the code below from a terminal on your computer
-	will add the right information to the `config` file
+
+	If you're not able to find or create the config file, executing the code below from the command line on your computer will add the right information to the `config` file
+
 	```	
 	# Let's create (or add to) our SSH client configuration file. 
 	echo "
@@ -68,89 +75,89 @@ This is the text that should be added to a file called `config` in the `.ssh` di
 	```
 	{:.term}
 
-1. You also create a directory that will be used to track connections. In 
-the same .ssh directory, make a folder called `connections` by typing: 
+1. You should also create a directory that will be used to track connections. In the same `.ssh` directory, make a folder called `connections` by typing: 
+
 	```
 	mkdir -p ~/.ssh/connections
 	```
-	{: .term}
+	{:.term}
 	
-	Once you login to a CHTC server, this is where the system will store information 
-	about your previous connection information so that you do not have to reenter your 
-	password or Duo authenticate. 
+	Once you log in to a CHTC server, your computer will store previous connection information in the `connections` directory so that you do not have to re-enter your password or Duo authenticate. 
 
-4. Now, log into your CHTC submit server or login node as normal. The first time you log in, you will need to use 
-two-factor authentication, but subsequent logins **to that machine** will not require 
-authentication as long as they occur within the time value used in 
-the `ControlPersist` configuration option (so in this example, 2 hours). 
+4. Log into your CHTC access point. The first time you log in, you will need to use Duo MFA, but subsequent logins **to that machine** will not require authentication as long as they occur within the time value used in the `ControlPersist` configuration option (in this example, 2 hours). 
 
-For Windows users who use PuTTY to log in, you need to go to 
-the `Connection -> SSH` section in the “Category” menu on the left side, 
-and then check the “Share SSH Connection if possible” box. If you don’t 
-see this option, try downloading a newer version of PuTTY.  
+### PuTTY users
 
-### Ending “Stuck” Connections
+1. Go the `Connection -> SSH` section in the “Category” menu on the left side.
+2. Check the “Share SSH Connection if possible” box. If you don’t see this option, try downloading a newer version of PuTTY.
 
-Sometimes a connection goes stale and you can’t reconnect using it, even if 
-it is within the timeout window. In this case, you can avoid using the existing 
-connection by removing the relevant file in `~/.ssh/connections`; This will probably 
-look something like: 
+## End hanging or stuck connections
 
-```
-$ ls ~/.ssh/connections/
-alice@submit.chtc.wisc.edu:22
-$ rm ~/.ssh/connections/alice@submit.chtc.wisc.edu:22
-```
-{:.term}
+Sometimes, a connection goes stale. When trying to reconnect, the terminal hangs or gets stuck. This may occur even if within the timeout window. To fix this, we will need to remove the existing connection by removing the relevant file in `~/.ssh/connections`.
 
-### Connection settings
+1. If the connection is hanging or stuck, use `CTRL + C` to cancel connecting.
 
-Note that all port forwarding, including X display forwarding, must be setup by 
-the initial connection and cannot be changed. If you forget to use `-Y` on the initial 
-connection, you will not be able to open X programs on subsequent connections.
+2. Locate the connection in the `~/.ssh/connections` directory.
 
-## File Transfer Tools
+    ```
+    [user@local]$ ls ~/.ssh/connections
+    user_ap2002_22
+    ```
+    {:.term}
 
-There are a variety of tools that people use for transferring and editing files 
-like WinSCP and MobaXTerm. Some of these tools are able to use ssh configuration 
-or have options that do not require Duo 2FA every time a file is uploaded or 
-downloaded or edited, but some do not. 
-
-### Known to support persistent connections
-
-* Linux, Mac, and Windows Subsystem for Linux (WSL) terminals
-
-* WinSCP
+3. Remove the connection.
     
-    May need to adjust preferences.  Within WinSCP:
+    ```
+    [user@local]$ rm ~/.ssh/connections/user_ap2002_22
+    ```
+    {:.term}
+
+4. Log in again.
+
+## Port forwarding
+
+All port forwarding, including X display forwarding, must be set up by the initial connection and cannot be changed. If you forget to use `-Y` on the initial connection, you will not be able to open X programs on subsequent connections.
+
+## Enable persistent connections in other programs
+
+### WinSCP
     
-    1. Go to Options, then Preferences, and click on Background under the Transfer section.  
-    2. Set 'Maximal number of transfers at the same time:' to 1.
-    3. Make sure 'Use multiple connections for single transfer' checkbox is checked.
-    4. Click 'OK' to save.
+Adjust preferences in WinSCP:
+    
+1. Go to Options, then Preferences, and click on Background under the Transfer section.  
+2. Set 'Maximal number of transfers at the same time:' to 1.
+3. Make sure 'Use multiple connections for single transfer' checkbox is checked.
+4. Click 'OK' to save.
 
-* Cyberduck (taken from [these docs](https://southernmethodistuniversity.github.io/hpc_docs/)
+### Cyberduck
 
-    Cyberduck does not use SSH configurations, therefore the following setting 
-    can be used to enable connection persistence. Within Cyberduck:
+Cyberduck does not use SSH configurations but can be set to enable persistent connections. (Steps based off [these docs](https://southernmethodistuniversity.github.io/hpc_docs/)).
 
-    1. Select Preferences, then the Transfers button, and then the General section.
-    1. Under “Transfers”, use the “Transfer Files” drop-down to select “Use browser 
-connection”.
+1. Select Preferences, then the Transfers button, and then the General section.
+2. Under “Transfers”, use the “Transfer Files” drop-down to select “Use browser connection”.
 
-<h3>Known to NOT support <code class="h3">ControlMaster</code> or similar persistent connections</h3>
+### Unsupported programs
 
 * Windows PowerShell
-
 * File transfer tools from [Panic](https://panic.com/), like Transmit and Nova
 
 ## Other Tools
 
-For those on spotty wireless or those who move a lot with their connection 
-(and on \*nix) then the open source shell Mosh (https://mosh.org/) has capabilities 
-to keep sessions open as you change connections. Note that Mosh doesn’t support the 
-following SSH features:
+For those on spotty wireless or those who move a lot with their connection, then the open source shell [Mosh](https://mosh.org/) has capabilities to keep sessions open as you change connections. Note that Mosh doesn’t support the following SSH features:
+
 * ControlMaster (connection multiplexing) 
 * X11 forwarding
 * Port forwarding
 
+## Summary
+
+Users should know:
+
+* the benefits of persistent connections
+* how to enable persistent connections in their SSH configuration file
+* how to enable persistent connections in programs like WinSCP and Cyberduck
+* how to enable persistent connections during port forwarding
+
+## Related pages
+
+* [Log in to CHTC](connecting)

--- a/_uw-research-computing/connecting.md
+++ b/_uw-research-computing/connecting.md
@@ -11,41 +11,42 @@ guide:
         - hpc
 ---
 
-# Introduction
+## Introduction
 
 This guide outlines login information for CHTC services, including how to log in to CHTC servers after your account has been created, access point information, and how to re-use ssh connections to reduce the frequency of using Duo Multi-factor Authentication.
 
 If you don't have an account, see our [getting started](get-started.html) page.
 
 {% capture content %}
-1.  [Access points](#access)
-2.  [Logging In](#login)
-    -   [On the command line](#login-ssh)
-    -   [Using an SSH program (Windows/Mac)](#login-putty)
-    -   [Re-using SSH connections](#c-re-using-ssh-connections)
-3.  [Learning about the command line](#learn)
+- [Introduction](#introduction)
+- [1. Before you log in](#1-before-you-log-in)
+   * [Hostname / Access point information](#hostname--access-point-information)
+- [2. Log in](#2-log-in)
+   * [Log in with the command line](#log-in-with-the-command-line)
+   * [Log in with an SSH program (Windows)](#log-in-with-an-ssh-program-windows)
+   * [Log out](#log-out)
 {% endcapture %}
 {% include /components/directory.html title="Table of Contents" %}
 
-# 1. Before you log in
+## Before you log in
 
 After obtaining a CHTC account, you will need the following to log into our CHTC access points:
 
-## Duo Multi-factor authentication (MFA)
+### Duo Multi-factor authentication (MFA)
 
 - [Set up Duo Multi-factor authentication](https://it.wisc.edu/services/duo-multi-factor-authentication-mfa/)
 
-## Connection to the campus network or Virtual Private Network (VPN)
+### Connection to the campus network or Virtual Private Network (VPN)
 
 All of our CHTC acccess points are firewalled to block log-ins from off-campus. If you are off-campus and want to log in, you can either:
 * Activate the campus Virtual Private Network (VPN) (see [DoIT's VPN webpage](https://it.wisc.edu/services/wiscvpn/)). This will allow you join the campus network when working off-campus. 
 * Log into another computer that is on campus (typically by SSH-ing into that computer) and then SSH to our access point. 
 
-## Username and Password
+### Username and Password
 
 - UW-Madison NetID and password
 
-## Hostname / Access point information
+### Hostname / Access point information
 
 Please use the access point specified in your welcome email.
 
@@ -61,11 +62,11 @@ Please use the access point specified in your welcome email.
   | `spark-login.chtc.wisc.edu` |
 
 
-# 2. Log in
+## Log in
 
 You can log in to the access points two different ways — from the command line or using an SSH program.
 
-## Log in with the command line
+### Log in with the command line
 
 On Mac, Linux, and modern Windows (10+) systems, you can use the "Terminal" application to log in. Open a terminal window and use the following command to connect to the appropriate server:
 
@@ -78,7 +79,7 @@ You will be prompted for your password, then for Duo authentication.
 
 <a name="login-putty"></a>
 
-## Log in with an SSH program (Windows)
+### Log in with an SSH program (Windows)
 
 There are multiple programs to connect to remote servers for Windows. We recommend "PuTTy", which can be downloaded [here](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html). To log in, run the PuTTy executable (`putty.exe`). The PuTTY Configuration options will load in a new window.
 
@@ -88,51 +89,109 @@ Fill in the hostname with the [hostname for your access point](#hostname). Use P
 
 After clicking "Open", you will be prompted to fill in your username and password, then to authenticate with Duo. 
 
-## Demo
+### Demo
 
 See the following video for a demonstration of logging into CHTC and authenticating with Duo Multi-factor Authentication.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/J-wxsrQ3v04" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
+
 ## Log out
 
 Log out by entering `exit` into the command line. Any submitted jobs will run and return output without you needing to be connected.
 
+## Reuse SSH connections to reduce login frequency
 
-# 3. Re-using SSH Connections
+You can reuse an SSH connection to 
 
-To reduce the number of times it is necessary to enter your credentials, you can customize your SSH configuration in a way that allows you to "reuse" a connection for logging in again or moving files.
+To reduce the number of times it is necessary to enter your credentials, it’s possible 
+to customize your SSH configuration in a way that allows you to “reuse” a connection 
+for logging in again or moving files.  This configuration is optional, and 
+most useful if you will connect to 
+the same server multiple times in a short window, for example, when uploading or 
+downloading files. 
 
+**WARNING:** This guide describes how to configure your local machine to not require 
+reentering your NetID password or Duo authentication each time you login. 
+This should **ONLY** be used on secure devices that you manage - **it should 
+not be used on any shared laptop, desktop, or research group resource. Users 
+found violating this policy risk having their CHTC account permanently deactivated.** 
 
-# 3. Learning About the Command Line
+The instructions below are meant for users who can use a terminal (Mac, Linux, newer Windows operating systems): 
 
-**Why learn about the command line?** If you haven\'t used the command
-line before, it might seem like a big challenge to get started, and
-easier to use other tools, especially if you have a Windows computer.
-However, we strongly recommend learning more about the command line for
-multiple reasons:
+1. Open a terminal window.
 
--   You can do most of what you need to do in CHTC by learning a few
-    basic commands.
--   With a little practice, typing on the command line is significantly
-    faster and much more powerful than using a point-and-click graphic
-    interface.
--   Command line skills are useful for more than just large-scale
-    computing.
+1. Create (or edit) your personal SSH configuration file at `~/.ssh/config` to use 
+what’s called "ControlMaster"
+This is the text that should be added to a file called `config` in the `.ssh` directory in your computer's home directory: 
 
-For a good overview of command line tools, see the [Software Carpentry
-Unix Shell](http://swcarpentry.github.io/shell-novice/) lesson. In
-particular, we recommend the sections on:
+	```	
+	Host *.chtc.wisc.edu
+	  # Turn ControlMaster on
+	  ControlMaster auto
+	  # ControlMaster connection will persist
+	  # for 2 hours of idleness, after which
+	  # it will disconnect
+	  ControlPersist 2h
+	  # Where to store files that represent
+	  # the ControlMaster persistent connections
+	  ControlPath ~/.ssh/connections/%r@%h:%p
+	```
+	If you're not able to find or create the config file, executing the code below from a terminal on your computer
+	will add the right information to the `config` file
+	```	
+	# Let's create (or add to) our SSH client configuration file. 
+	echo "
+	Host *.chtc.wisc.edu
+	  # Turn ControlMaster on
+	  ControlMaster auto
+	  # ControlMaster connection will persist
+	  # for 2 hours of idleness, after which
+	  # it will disconnect
+	  ControlPersist 2h
+	  # Where to store files that represent
+	  # the ControlMaster persistent connections
+	  ControlPath ~/.ssh/connections/%r@%h:%p" >> ~/.ssh/config
+	```
+	{:.term}
 
--   understanding the filesystem and how to navigate it ([Navigating
-    Files and Directories](https://swcarpentry.github.io/shell-novice/02-filedir.html))
--   tab-completion (section entitled \"Nelle\'s Pipeline, Organizing
-    Files\", in [Navigating Files and
-    Directories](https://swcarpentry.github.io/shell-novice/02-filedir.html))
--   creating files ([Working With Files and
-    Directories](https://swcarpentry.github.io/shell-novice/03-create.html))
--   using the star wildcard (first part of [Pipes and
-    Filters](https://swcarpentry.github.io/shell-novice/04-pipefilter.html))
--   writing shell scripts ([Shell
-    Scripts](https://swcarpentry.github.io/shell-novice/06-script.html))
+1. You also create a directory that will be used to track connections. In 
+the same .ssh directory, make a folder called `connections` by typing: 
+	```
+	mkdir -p ~/.ssh/connections
+	```
+	{: .term}
+	
+	Once you login to a CHTC server, this is where the system will store information 
+	about your previous connection information so that you do not have to reenter your 
+	password or Duo authenticate. 
 
+4. Now, log into your CHTC submit server or login node as normal. The first time you log in, you will need to use 
+two-factor authentication, but subsequent logins **to that machine** will not require 
+authentication as long as they occur within the time value used in 
+the `ControlPersist` configuration option (so in this example, 2 hours). 
+
+For Windows users who use PuTTY to log in, you need to go to 
+the `Connection -> SSH` section in the “Category” menu on the left side, 
+and then check the “Share SSH Connection if possible” box. If you don’t 
+see this option, try downloading a newer version of PuTTY.  
+
+#### Ending “Stuck” Connections
+
+Sometimes a connection goes stale and you can’t reconnect using it, even if 
+it is within the timeout window. In this case, you can avoid using the existing 
+connection by removing the relevant file in `~/.ssh/connections`; This will probably 
+look something like: 
+
+```
+$ ls ~/.ssh/connections/
+alice@submit.chtc.wisc.edu:22
+$ rm ~/.ssh/connections/alice@submit.chtc.wisc.edu:22
+```
+{:.term}
+
+#### Connection settings
+
+Note that all port forwarding, including X display forwarding, must be setup by 
+the initial connection and cannot be changed. If you forget to use `-Y` on the initial 
+connection, you will not be able to open X programs on subsequent connections.

--- a/_uw-research-computing/connecting.md
+++ b/_uw-research-computing/connecting.md
@@ -1,8 +1,8 @@
 ---
 highlighter: none
 layout: guide
-title: Log In to CHTC Resources
-alt_title: Connect to CHTC
+title: Log in to CHTC
+alt_title: Log in to CHTC
 guide:
     order: 2
     category: Basics and Policies
@@ -13,18 +13,21 @@ guide:
 
 ## Introduction
 
-This guide outlines login information for CHTC services, including how to log in to CHTC servers after your account has been created, access point information, and how to re-use ssh connections to reduce the frequency of using Duo Multi-factor Authentication.
+This guide outlines login information for CHTC services, including how to log in to CHTC servers after your account has been created, access point information, and how to re-use ssh connections to reduce the frequency of using Duo Multi-factor Authentication (MFA).
 
 If you don't have an account, see our [getting started](get-started.html) page.
 
 {% capture content %}
 - [Introduction](#introduction)
-- [1. Before you log in](#1-before-you-log-in)
-   * [Hostname / Access point information](#hostname--access-point-information)
-- [2. Log in](#2-log-in)
-   * [Log in with the command line](#log-in-with-the-command-line)
-   * [Log in with an SSH program (Windows)](#log-in-with-an-ssh-program-windows)
-   * [Log out](#log-out)
+- [Before you log in](#before-you-log-in)
+- [Hostname / Access point information](#hostname--access-point-information)
+- [Log in](#log-in)
+   * [Log in with a terminal](#log-in-with-a-terminal)
+   * [Log in with PuTTY, an SSH program for Windows](#log-in-with-putty-an-ssh-program-for-windows)
+- [Log out](#log-out)
+- [SSH programs](#ssh-programs)
+- [Summary](#summary)
+- [Related pages](#related-pages)
 {% endcapture %}
 {% include /components/directory.html title="Table of Contents" %}
 
@@ -32,21 +35,11 @@ If you don't have an account, see our [getting started](get-started.html) page.
 
 After obtaining a CHTC account, you will need the following to log into our CHTC access points:
 
-### Duo Multi-factor authentication (MFA)
+* [Duo Multi-factor authentication (MFA)](https://it.wisc.edu/services/duo-multi-factor-authentication-mfa/)
+* [a connection to the campus network or Virtual Private Network (VPN)](https://it.wisc.edu/services/wiscvpn/)
+* a username and password (typically your UW-Madison NetID and password)
 
-- [Set up Duo Multi-factor authentication](https://it.wisc.edu/services/duo-multi-factor-authentication-mfa/)
-
-### Connection to the campus network or Virtual Private Network (VPN)
-
-All of our CHTC acccess points are firewalled to block log-ins from off-campus. If you are off-campus and want to log in, you can either:
-* Activate the campus Virtual Private Network (VPN) (see [DoIT's VPN webpage](https://it.wisc.edu/services/wiscvpn/)). This will allow you join the campus network when working off-campus. 
-* Log into another computer that is on campus (typically by SSH-ing into that computer) and then SSH to our access point. 
-
-### Username and Password
-
-- UW-Madison NetID and password
-
-### Hostname / Access point information
+## Hostname / Access point information
 
 Please use the access point specified in your welcome email.
 
@@ -64,134 +57,71 @@ Please use the access point specified in your welcome email.
 
 ## Log in
 
-You can log in to the access points two different ways — from the command line or using an SSH program.
+You can log in to the access points two different ways — from a terminal program or using an SSH program.
 
-### Log in with the command line
+See [this table](#ssh-programs) for a list of terminal/SSH programs.
 
-On Mac, Linux, and modern Windows (10+) systems, you can use the "Terminal" application to log in. Open a terminal window and use the following command to connect to the appropriate server:
+### Log in with a terminal
 
-``` 
-ssh username@hostname
-```
-{:.term}
+1. Open a terminal window. Enter the following command, where `user` is your username (typically your NetID) and `hostname.chtc.wisc.edu` is your assigned access point in your welcome email.
 
-You will be prompted for your password, then for Duo authentication. 
+    ``` 
+    ssh username@hostname.chtc.wisc.edu
+    ```
+    {:.term}
 
-<a name="login-putty"></a>
+2. You will be prompted for your password, then for Duo MFA authentication.
 
-### Log in with an SSH program (Windows)
+### Log in with PuTTY, an SSH program for Windows
 
-There are multiple programs to connect to remote servers for Windows. We recommend "PuTTy", which can be downloaded [here](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html). To log in, run the PuTTy executable (`putty.exe`). The PuTTY Configuration options will load in a new window.
+There are multiple programs to connect to remote servers for Windows. We recommend "PuTTy", which can be downloaded [here](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html).
 
-![The PuTTY Configuration window](/images/putty-7.jpeg)
+1. To log in, run the PuTTy executable (`putty.exe`). The PuTTY Configuration options will load in a new window.
 
-Fill in the hostname with the [hostname for your access point](#hostname). Use Port 22 and the "SSH" connection type — these are usually the defaults.
+    ![The PuTTY Configuration window](/images/putty-7.jpeg)
 
-After clicking "Open", you will be prompted to fill in your username and password, then to authenticate with Duo. 
+2. Fill in the hostname with the [hostname for your access point](#hostname). Use Port 22 and the "SSH" connection type — these are usually the defaults.
 
-### Demo
+3. After clicking "Open", you will be prompted to fill in your username and password, then to authenticate with Duo. 
 
-See the following video for a demonstration of logging into CHTC and authenticating with Duo Multi-factor Authentication.
+> ### 🎞️ Demo: Log into a CHTC access point
+{:.tip-header}
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/J-wxsrQ3v04" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
+> This video demonstrates how to log into CHTC and authenticate with Duo MFA.
+> <iframe width="560" height="315" src="https://www.youtube.com/embed/J-wxsrQ3v04" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+{:.tip}
 
 ## Log out
 
 Log out by entering `exit` into the command line. Any submitted jobs will run and return output without you needing to be connected.
 
-## Reuse SSH connections to reduce login frequency
+## SSH programs
 
-You can reuse an SSH connection to 
+This is a non-exhaustive list of programs that can be used to log into CHTC servers or transfer files.
 
-To reduce the number of times it is necessary to enter your credentials, it’s possible 
-to customize your SSH configuration in a way that allows you to “reuse” a connection 
-for logging in again or moving files.  This configuration is optional, and 
-most useful if you will connect to 
-the same server multiple times in a short window, for example, when uploading or 
-downloading files. 
+| Operating system | Program | Type | Supports [Persistent Connections](configure-ssh) | Notes |
+| --- | --- | --- | --- |
+| Linux | Terminal | terminal | ✓ | pre-installed |
+| MacOS | Terminal | terminal | ✓ | pre-installed |
+| | [Cyberduck](https://cyberduck.io/) | file-transfer utility | ✓ | |
+| Windows | [PuTTY](https://www.putty.org/) | SSH client | ✓ | recommended for beginning users |
+| | [Terminal (Windows Subshell for Linux)](https://learn.microsoft.com/en-us/windows/wsl/install) | terminal | ✓ | recommended for users familiar with the Unix shell |
+| | [MobaXTerm](https://mobaxterm.mobatek.net/) | terminal, SSH client, file-transfer utility | ✓ | |
+| | [WinSCP](https://winscp.net/eng/index.php) | file-transfer utility | ✓ |
+| Linux, MacOS, Windows | [VSCode](https://code.visualstudio.com/) | terminal, limited file-transfer utility, integrated code editor | only on MacOS/Linux/WSL | [setup](https://code.visualstudio.com/docs/remote/ssh-tutorial) (ignore steps on creating a virtual machine) |
+| Linux, MacOS, Chrome, and more | [Mosh](https://mosh.org/) | terminal | X | |
 
-**WARNING:** This guide describes how to configure your local machine to not require 
-reentering your NetID password or Duo authentication each time you login. 
-This should **ONLY** be used on secure devices that you manage - **it should 
-not be used on any shared laptop, desktop, or research group resource. Users 
-found violating this policy risk having their CHTC account permanently deactivated.** 
+## Summary
 
-The instructions below are meant for users who can use a terminal (Mac, Linux, newer Windows operating systems): 
+From this guide, users should know:
+* the information and connections necessary to log in
+* hostname of their access point
+* how to log in to their CHTC access point
+* how to log out of their access point
+* programs they can use to log in to CHTC
 
-1. Open a terminal window.
+## Related pages
 
-1. Create (or edit) your personal SSH configuration file at `~/.ssh/config` to use 
-what’s called "ControlMaster"
-This is the text that should be added to a file called `config` in the `.ssh` directory in your computer's home directory: 
-
-	```	
-	Host *.chtc.wisc.edu
-	  # Turn ControlMaster on
-	  ControlMaster auto
-	  # ControlMaster connection will persist
-	  # for 2 hours of idleness, after which
-	  # it will disconnect
-	  ControlPersist 2h
-	  # Where to store files that represent
-	  # the ControlMaster persistent connections
-	  ControlPath ~/.ssh/connections/%r@%h:%p
-	```
-	If you're not able to find or create the config file, executing the code below from a terminal on your computer
-	will add the right information to the `config` file
-	```	
-	# Let's create (or add to) our SSH client configuration file. 
-	echo "
-	Host *.chtc.wisc.edu
-	  # Turn ControlMaster on
-	  ControlMaster auto
-	  # ControlMaster connection will persist
-	  # for 2 hours of idleness, after which
-	  # it will disconnect
-	  ControlPersist 2h
-	  # Where to store files that represent
-	  # the ControlMaster persistent connections
-	  ControlPath ~/.ssh/connections/%r@%h:%p" >> ~/.ssh/config
-	```
-	{:.term}
-
-1. You also create a directory that will be used to track connections. In 
-the same .ssh directory, make a folder called `connections` by typing: 
-	```
-	mkdir -p ~/.ssh/connections
-	```
-	{: .term}
-	
-	Once you login to a CHTC server, this is where the system will store information 
-	about your previous connection information so that you do not have to reenter your 
-	password or Duo authenticate. 
-
-4. Now, log into your CHTC submit server or login node as normal. The first time you log in, you will need to use 
-two-factor authentication, but subsequent logins **to that machine** will not require 
-authentication as long as they occur within the time value used in 
-the `ControlPersist` configuration option (so in this example, 2 hours). 
-
-For Windows users who use PuTTY to log in, you need to go to 
-the `Connection -> SSH` section in the “Category” menu on the left side, 
-and then check the “Share SSH Connection if possible” box. If you don’t 
-see this option, try downloading a newer version of PuTTY.  
-
-#### Ending “Stuck” Connections
-
-Sometimes a connection goes stale and you can’t reconnect using it, even if 
-it is within the timeout window. In this case, you can avoid using the existing 
-connection by removing the relevant file in `~/.ssh/connections`; This will probably 
-look something like: 
-
-```
-$ ls ~/.ssh/connections/
-alice@submit.chtc.wisc.edu:22
-$ rm ~/.ssh/connections/alice@submit.chtc.wisc.edu:22
-```
-{:.term}
-
-#### Connection settings
-
-Note that all port forwarding, including X display forwarding, must be setup by 
-the initial connection and cannot be changed. If you forget to use `-Y` on the initial 
-connection, you will not be able to open X programs on subsequent connections.
+* [Automate CHTC log in](configure-ssh)
+* [Basic shell commands](basic-shell-commands)
+* [Transfer files to/from CHTC and your computer](transfer-files-computer)

--- a/_uw-research-computing/connecting.md
+++ b/_uw-research-computing/connecting.md
@@ -11,13 +11,14 @@ guide:
         - hpc
 ---
 
-This guide assumes
-that you have already gotten a CHTC account for either our high
-throughput or high performance compute systems. If you haven\'t, see our
-[getting started](get-started.html) page.
+# Introduction
+
+This guide outlines login information for CHTC services, including how to log in to CHTC servers after your account has been created, access point information, and how to re-use ssh connections to reduce the frequency of using Duo Multi-factor Authentication.
+
+If you don't have an account, see our [getting started](get-started.html) page.
 
 {% capture content %}
-1.  [Accessing the Submit Servers](#access)
+1.  [Access points](#access)
 2.  [Logging In](#login)
     -   [On the command line](#login-ssh)
     -   [Using an SSH program (Windows/Mac)](#login-putty)
@@ -26,120 +27,84 @@ throughput or high performance compute systems. If you haven\'t, see our
 {% endcapture %}
 {% include /components/directory.html title="Table of Contents" %}
 
-<a name="access"></a>
+# 1. Before you log in
 
-**1. Accessing the Submit Servers**
-===============================
+After obtaining a CHTC account, you will need the following to log into our CHTC access points:
 
-You will need the following information to log into our CHTC submit
-servers or head nodes:
+## Duo Multi-factor authentication (MFA)
 
-**Username and Password**
+- [Set up Duo Multi-factor authentication](https://it.wisc.edu/services/duo-multi-factor-authentication-mfa/)
+
+## Connection to the campus network or Virtual Private Network (VPN)
+
+All of our CHTC acccess points are firewalled to block log-ins from off-campus. If you are off-campus and want to log in, you can either:
+* Activate the campus Virtual Private Network (VPN) (see [DoIT's VPN webpage](https://it.wisc.edu/services/wiscvpn/)). This will allow you join the campus network when working off-campus. 
+* Log into another computer that is on campus (typically by SSH-ing into that computer) and then SSH to our access point. 
+
+## Username and Password
 
 - UW-Madison NetID and password
 
-**Hostname**
+## Hostname / Access point information
+
+Please use the access point specified in your welcome email.
 
   {:.gtable}
-  | HTC System |
+  | High Throughput Computing (HTC) System |
   | --- |
   | `ap2001.chtc.wisc.edu` |
   | `ap2002.chtc.wisc.edu` |
 
   {:.gtable}
-  | HPC Cluster |
+  | High Performance Computing (HPC) System |
   | --- |
   | `spark-login.chtc.wisc.edu` |
 
-As of December 2022, we also require two-factor authentication with Duo to 
-access CHTC resources. 
 
-> **Are you off-campus?**\
-> All of our CHTC submit servers and head nodes are firewalled to block
-> log-ins from off-campus. If you are off-campus and want to log in, you
-> can either:
->
-> -   Activate the campus Virtual Private Network (VPN) (more details on how to set this up
->     [DoIT's VPN webpage](https://it.wisc.edu/services/wiscvpn/)). This will allow you join the campus network when working off-campus. 
-> -   Log into another computer that is on campus (typically by SSH-ing into that computer) and then SSH to our submit server. 
->
-> In either case, it will appear like you are on-campus, and you should
-> then be able to log into CHTC as usual.
+# 2. Log in
 
-<a name="login"></a>
+You can log in to the access points two different ways — from the command line or using an SSH program.
 
-**2. Logging In**
-=============
+## Log in with the command line
 
-Using the information described above, you can log in to servers two
-different ways \-- from the command line or using an SSH program:
-
-
-<a name="login-ssh"></a>
-
-A. On the command line
-----------------------------------
-
-On Mac, Linux, and modern Windows (10+) systems, you can use the \"Terminal\" application to
-log in. Open a terminal window and use the following command to connect
-to the appropriate server:
+On Mac, Linux, and modern Windows (10+) systems, you can use the "Terminal" application to log in. Open a terminal window and use the following command to connect to the appropriate server:
 
 ``` 
-$ ssh username@hostname
+ssh username@hostname
 ```
 {:.term}
 
-You will be prompted for your password, and then for Duo 
-authentication. 
+You will be prompted for your password, then for Duo authentication. 
 
 <a name="login-putty"></a>
 
-B. Using an SSH program (Windows)
----------------------------------
+## Log in with an SSH program (Windows)
 
-There are multiple programs to connect to remote servers for Windows. We
-recommend \"PuTTy\", which can be downloaded
-[here](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html).
-To log in, click on the PuTTy executable (`putty.exe`). You should see a
-screen like this:
+There are multiple programs to connect to remote servers for Windows. We recommend "PuTTy", which can be downloaded [here](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html). To log in, run the PuTTy executable (`putty.exe`). The PuTTY Configuration options will load in a new window.
 
-![](/images/putty-7.jpeg)
+![The PuTTY Configuration window](/images/putty-7.jpeg)
 
-Fill in the hostname as described in part 1. You should use Port 22 and
-connect using \"ssh\" \-- these are usually the defaults. After you
-click \"connect\" you will be prompted to fill in your username and
-password, and then to authenticate with Duo. 
+Fill in the hostname with the [hostname for your access point](#hostname). Use Port 22 and the "SSH" connection type — these are usually the defaults.
 
-Note that once you have submitted jobs to the queue, you can leave your
-logged in session (by typing `exit`). Your jobs will run and return
-output without you needing to be connected.
+After clicking "Open", you will be prompted to fill in your username and password, then to authenticate with Duo. 
 
-<!-- <a name="ssh-keys"></a>
+## Demo
 
-C. Logging in automatically
----------------------------
+See the following video for a demonstration of logging into CHTC and authenticating with Duo Multi-factor Authentication.
 
-Tired of typing your password everytime you log in? It\'s possible to
-set up a file on your local computer called an ssh key, that allows you
-to log into CHTC and transfer files without entering your password. [See
-this guide](http://www.howtogeek.com/66776/how-to-remotely-copy-files-over-ssh-without-entering-your-password/)
-for instructions on how to do this, starting at the section titled
-**\"SSH and SCP Without Passwords\"**. -->
+<iframe width="560" height="315" src="https://www.youtube.com/embed/J-wxsrQ3v04" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+## Log out
+
+Log out by entering `exit` into the command line. Any submitted jobs will run and return output without you needing to be connected.
 
 
-C. Re-Using SSH Connections
----------------------------
+# 3. Re-using SSH Connections
 
-To reduce the number of times it is necessary to enter your credentials, it’s 
-possible to customize your SSH configuration in a way that allows you to "reuse" 
-a connection for logging in again or moving files. More details are shown 
-in this guide: [Automating CHTC Log In](/uw-research-computing/configure-ssh.html)
+To reduce the number of times it is necessary to enter your credentials, you can customize your SSH configuration in a way that allows you to "reuse" a connection for logging in again or moving files.
 
 
-<a name="learn"></a>
-
-**3. Learning About the Command Line**
-==================================
+# 3. Learning About the Command Line
 
 **Why learn about the command line?** If you haven\'t used the command
 line before, it might seem like a big challenge to get started, and

--- a/assets/css/research-style.css
+++ b/assets/css/research-style.css
@@ -32,3 +32,43 @@ pre.other {
     border-left: 0px solid #0D4F8B;
     padding: 0.5em 1.2em;
 }
+
+blockquote.tip-header {
+	border-radius: 5px 5px 0 0;
+   -moz-border-radius: 5px 5px 0 0;
+   -webkit-border-radius: 5px 5px 0 0;
+    font-style: normal;
+	margin: 1em 2em;
+    background: #f9e6e7;
+    color: #333;
+    border-top: 2px solid #B70101;
+    border-left: 2px solid #B70101;
+    border-right: 2px solid #B70101;
+	padding: 0.5em 1.2em;
+    margin-bottom: 0px;
+}
+
+blockquote.tip-header h2{
+    color: #B70101;
+}
+
+blockquote.tip {
+	border-radius: 0 0 5px 5px;
+   -moz-border-radius: 0 0 5px 5px;
+   -webkit-border-radius: 0 0 5px 5px;
+    font-style: normal;
+	margin: 1em 2em;
+    background: #fff;
+    color: #333;
+    border: 2px solid #B70101;
+	padding: 0.5em 1.2em;
+    margin-top: 0px;
+}
+
+blockquote.tip p {
+    font-size: 1.125rem;
+}
+
+blockquote.tip ul, ol {
+    margin-left:2em;
+}

--- a/assets/css/research-style.css
+++ b/assets/css/research-style.css
@@ -48,7 +48,8 @@ blockquote.tip-header {
     margin-bottom: 0px;
 }
 
-blockquote.tip-header h2{
+blockquote.tip-header h2, blockquote.tip-header h3 {
+    margin: 0.9rem 0;
     color: #B70101;
 }
 
@@ -56,7 +57,7 @@ blockquote.tip {
 	border-radius: 0 0 5px 5px;
    -moz-border-radius: 0 0 5px 5px;
    -webkit-border-radius: 0 0 5px 5px;
-    font-style: normal;
+    font-style: unset;
 	margin: 1em 2em;
     background: #fff;
     color: #333;
@@ -67,8 +68,13 @@ blockquote.tip {
 
 blockquote.tip p {
     font-size: 1.125rem;
+    margin: 0.75rem 0;
 }
 
-blockquote.tip ul, ol {
+blockquote.tip em {
+    font-style: italic;
+}
+
+blockquote.tip ul, blockquote.tip ol {
     margin-left:2em;
 }


### PR DESCRIPTION
Major changes
* Added [Basic Shell Commands](https://chtc.github.io/web-preview/preview-xalim-login/uw-research-computing/basic-shell-commands)
* Added [custom CSS](https://github.com/CHTC/chtc-website-source/blob/e7d93f1eca4037ca09b85b72a5f59623e9e37597/assets/css/research-style.css#L36-L80), particularly adding a new block quote style that can be enabled by appending `{:.tip-header}` and `{:.tip}` to block quotes. See an example [here](https://chtc.github.io/web-preview/preview-xalim-login/uw-research-computing/basic-shell-commands#for-beginning-users-get-started-with-the-command-line).

Less major (but still not minor) changes
* Revised [Log in to CHTC](https://chtc.github.io/web-preview/preview-xalim-login/uw-research-computing/connecting), including a [new table with SSH programs](https://chtc.github.io/web-preview/preview-xalim-login/uw-research-computing/connecting#ssh-programs)
* Revised [Automate CHTC login](https://chtc.github.io/web-preview/preview-xalim-login/uw-research-computing/configure-ssh)