### PR TITLE
Add event for OSG School 2025

### DIFF
--- a/_events/2025-06-23-osg-school-2025.md
+++ b/_events/2025-06-23-osg-school-2025.md
@@ -1,0 +1,74 @@
+---
+short_title: OSG School 2025
+title: "OSG School 2025"
+layout: events
+published: true
+excerpt: |
+    Applications for the OSG School 2025 at the University of Wisconsin-Madison are now open!
+start_date: 2025-06-23
+end_date: 2025-06-27
+location: "University of Wisconsin-Madison"
+link: "https://osg-htc.org/school-2025/"
+image: "/images/events/osg-school-2024-event.jpg"
+header_image: "/images/events/osg-school-2024-event.jpg"
+---
+
+{% capture main %}
+
+**Could you transform your research with vast amounts of computing?**
+
+Learn how this summer at the lovely University of Wisconsin–Madison.
+
+During the School — June 23–27 — you will learn to use high-throughput computing (HTC) systems, at your own campus or using the national-scale Open Science Pool, to run large-scale computing applications that are at the heart of today’s cutting-edge science.
+
+Through lectures, discussions, and lots of hands-on activities with experienced OSG staff, you will learn how HTC systems work, how to run and manage long lists of computing tasks and work with huge datasets to implement a scientific computing workflow, and where to turn for more information and help.
+
+The School is ideal for:
+
+* Researchers (especially graduate students and post-docs) in any research area for which large-scale computing is a vital part of the research process;
+
+* Anyone (especially students and staff) who supports researchers who are current or potential users of high-throughput computing;
+
+* Instructors (at the post-secondary level) who teach future researchers and see value in integrating high-throughput computing into their curriculum.
+
+People accepted to this program will receive financial support for basic travel and local costs associated with the School.
+
+<div class="d-flex mb-3">
+    <div class="p-3 m-auto">
+        <a class="btn btn-primary" href="https://osg-htc.org/school-2025">Apply now!</a>
+    </div>
+</div>
+
+
+{% endcapture %}
+
+
+{% capture subsection %}
+### Dates
+
+June 23-27, 2025
+
+### Who
+
+Researchers (especially graduate students and post-docs), students and staff who supports researchers currently or are potential users of HTC, and instructors at the post-secondary level who want to integrate HTC into their curriculum.
+ 
+### Where
+
+The University of Wisconsin-Madison.
+
+### Application and Deadlines
+Details about the application process can be found on the [OSG School 2025 site](https://osg-htc.org/school-2025).
+
+The deadline for applications is Friday, March 7, 2025.
+
+### Contact Us
+
+If you have any questions about the event, email us at [school@osg-htc.org](mailto:school@osg-htc.org)
+{% endcapture %}
+
+{% capture endblock %}
+
+
+{% endcapture %}
+
+{% include event/event-page.html %}


### PR DESCRIPTION
The page for the event isn't included in the preview, but you can see what the event looks like on the general events page here:
https://chtc.github.io/web-preview/preview-add-osg-school-2025/events.html