### PR TITLE
UWDF federation discoveryURL: fix issuer key after adding persistence

### DIFF
--- a/uwdf/public_signing_key.jwks
+++ b/uwdf/public_signing_key.jwks
@@ -3,10 +3,10 @@
     {
       "alg": "ES256",
       "crv": "P-256",
-      "kid": "gzRroZDaMi0fdACZTwJBYAS9FnEVCJvkgsiLOYkNyHo",
+      "kid": "ElZV0R_c79SCYHGyvCJDAnyuLVFhcICshcyMQyUTXp8",
       "kty": "EC",
-      "x": "earazAX6YzsoFy1ZRk0KH1hUsE0DGwHDyqsQ57__ZHw",
-      "y": "_JEsy_P5oNYkpsSeViT18r3seuEUfJAzNOw1-GOERlw"
+      "x": "EuVScVN_ss_xIJsjuhVkqaosWYutNPjCOgSfQC10a3U",
+      "y": "rOTf6d8UdZx-MPTdsyb6OxNl1duUQ8Vne2wBXr8GsMQ"
     }
   ]
 }


### PR DESCRIPTION
The UWDF Directors' Issuer keys weren't being persisted before (now fixed), so we need to replace the public key with the one that corresponds to the currently used private key.