### PR TITLE
Fixing broken metadata in htcondor-quick-ref.md

### DIFF
--- a/_uw-research-computing/htcondor-quick-ref.md
+++ b/_uw-research-computing/htcondor-quick-ref.md
@@ -1,4 +1,4 @@
-
+---
 layout: guide
 title: "Quick reference: HTCondor commands"
 alt_title: "Quick reference: HTCondor commands"


### PR DESCRIPTION
Last PR somehow dropped the first line.