### PR TITLE
Adjust code formatting to use size from parent

### DIFF
--- a/_sass/UW-theming/_uw_typography.scss
+++ b/_sass/UW-theming/_uw_typography.scss
@@ -305,7 +305,7 @@ pre {
   padding: 0.75em 1.625em;
 }
 code, kbd, samp, var {
-  font: 1rem Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
+  font: 1em Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
 }
 
 ins {


### PR DESCRIPTION
Currently, when using the `<code>` formatting for headers, the size of the corresponding text is too small. It would be great to have the css adjusted so that `<code>` uses the parent element to set the `font-size`.

Current example:
![image](https://github.com/user-attachments/assets/bde98b61-5b38-49db-87c9-065d643ea859)

Proposed example:
![image](https://github.com/user-attachments/assets/da64d916-6cf3-4a6a-91b2-9c38aee831bd)


