### PR TITLE
Adjust date formatting to fix event display order

### DIFF
--- a/_events/2025-02-01-throughput-computing-week-2025.md
+++ b/_events/2025-02-01-throughput-computing-week-2025.md
@@ -9,8 +9,8 @@ excerpt: |
     Don't miss this opportunity to connect with the High Throughput Computing community.
 
 
-start_date: 2025-06-2
-end_date: 2025-06-6
+start_date: 2025-06-02
+end_date: 2025-06-06
 location: "University of Wisconsin–Madison’s Fluno Center and Online via Zoom"
 image: "/images/events/throughput-2025-banners.png"
 header_image: "images/events/throughput-2025-banners.png"


### PR DESCRIPTION
Added `0`s to the event date to make sure HTC week is correctly displayed as the foremost upcoming event.