### PR TITLE
Exclude the events README in page build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,7 @@ include:
 
 exclude:
   - _events/images
+  - _events/README.md
 
 markdown_ext : "md,shtml"
 


### PR DESCRIPTION
`/events/:year/:month/:day/:title.md` was being generated as a page and breaking the GitHub actions artifact.