### PR TITLE
fix: merged introduction, added table of contents and related pages, new headers

### DIFF
--- a/_uw-research-computing/transfer-data-researchdrive.md
+++ b/_uw-research-computing/transfer-data-researchdrive.md
@@ -14,8 +14,8 @@ This guide shows how to transfer (upload/download) files between CHTC's file sys
 {% capture content %}
 - [Introduction](#introduction)
 - [Before you transfer](#before-you-transfer)
-- [Transferring Files](#transferring-files)
-- [Transferring a Batch of Files](#transferring-a-batch-of-files)
+- [Transfer Files](#transfer-files)
+- [Transfer a Batch of Files](#transfer-a-batch-of-files)
 - [Related pages](#related-pages)
 {% endcapture %}
 {% include /components/directory.html title="Table of Contents" %}
@@ -27,41 +27,48 @@ we assume that you are transferring files to and from our HTC system, but you ca
 use the same process to transfer files to and from the HPC cluster if you first log 
 in to one of the HPC login nodes. 
 
-## Transferring Files
+## Transfer Files
 
 To transfer data between ResearchDrive and CHTC, do the following: 
 
 1. **Log in:** 
 	1. If you are transferring files to or from a `/staging` directory, log in to `transfer.chtc.wisc.edu`. 
 	2. If you are transferring files and or from your `/home` directory, log into your usual submit server (typically `ap2001.chtc.wisc.edu` or `ap2002.chtc.wisc.edu`). 
-2. **Choose a folder:** Navigate to the folder in CHTC (`/staging` or `/home`), where you would like to transfer files. 
+2. **Choose a folder:** Navigate to the folder in CHTC (`/staging` or `/home`) where you would like to transfer files. 
 3. **Connect to ResearchDrive:** Run the following command to connect to ResearchDrive, filling in the username of 
 your PI: 
+
     ```
     [alice@server]$ smbclient -k //research.drive.wisc.edu/PI-Name
     ```
     {:.term}
 
     Your prompt should change to look like this:
+
     ```
     smb: \> 
     ```
     {:.term}
 
-    > ## Note about NetIDs
+    > ### Note about NetIDs
+    {:.tip-header}
     > If your CHTC account is not tied to your campus NetID or you are accessing a data 
     > storage service that doesn't use your NetID, you'll need to omit the `-k` flag above
+    {:.tip}
+
 4. **Choose a folder, part 2:** If you type `ls` now, you'll see the files in ResearchDrive, not CHTC. 
 Navigate through ResearchDrive (using `cd`) until you are at the folder where you would 
 like to get or put files. 
 5. **Move files:** To move files, you will use the `get` and `put` commands: 
     - To move files from CHTC to ResearchDrive, run: 
+
         ```
         smb: \> put filename
         ```
         {:.term}
 
     - To move files from ResearchDrive to CHTC, run: 
+
         ```
         smb: \> get filename
         ```
@@ -69,7 +76,7 @@ like to get or put files.
 
 6. **Finish:** Once you are done moving files, you can type `exit` to leave the connection to ResearchDrive. 
 
-## Transferring a Batch of Files
+## Transfer a Batch of Files
 
 The steps described above work well for transferring a single file, or tar archive of 
 many files, at a time and is best for transferring a few files in a session. However, 
@@ -77,71 +84,34 @@ many files, at a time and is best for transferring a few files in a session. How
 using the `*` wildcard character.
 
 To transfer multiple files at once, first you must turn off the `smbclient` file transfer prompt, 
-then use either `mget` or `mput` for your file transfer. For example, if you have multiple `fastq.gz` files
-to transfer to CHTC:
+then use either `mget` or `mput` for your file transfer.
 
-1. **Log in:** 
-	1. If you are transferring files to or from a `/staging` directory, log in to `transfer.chtc.wisc.edu`. 
-	2. If you are transferring files to or from your `/home` directory, log into your usual submit server (typically `ap2001.chtc.wisc.edu` or `ap2002.chtc.wisc.edu`). 
-2. **Choose a folder:** Navigate to the folder in CHTC (`/staging` or `/home`), where you would like to put the files. 
-3. **Connect to ResearchDrive:** Run the following command to connect to ResearchDrive, filling in the username of 
-your PI: 
-    ```
-    [alice@server]$ smbclient -k //research.drive.wisc.edu/PI-Name
-    ```
-    {:.term}
+1. Follow steps 1-4 above.
 
-4. **Navigate to appropriate ResearchDrive directory**
-    ```
-    smb: \> cd path/to/files
-    ```
-    {:.term}
+1. **Turn off Prompting**. This turns off a prompt that appears for every file you want to download.
 
-5. **Turn of Prompting**
     ```
     smb: \> prompt
     ```
     {:.term}
 
-6. **Use `mget` instead of `get`**
-	This command downloads a group of files that end with "fastq.gz" to CHTC. 
-    ```
-    smb: \> mget *.fastq.gz
-    ```
-    {:.term}
+1. **Move files**
+
+    - **Download with `mget`**.
+        The example below uses the wildcard character `*` to download a group of files that end with ".fastq.gz" to CHTC. 
+
+        ```
+        smb: \> mget *.fastq.gz
+        ```
+        {:.term}
  
-    
-As another example, use `smbclient` to transfer multiple `tar.gz` output files to ResearchDrive from CHTC
-after your jobs complete:
+    - **Upload with `mput`**.
+        The example below uses the wildcard character `*` to upload a group of files that end with ".tar.gz" to CHTC. 
 
-1. **Log in:** 
-	1. If you are transferring files to or from a `/staging` directory, log in to `transfer.chtc.wisc.edu`. 
-	2. If you are transferring files to or from your `/home` directory, log into your usual submit server (typically `ap2001.chtc.wisc.edu` or `ap2002.chtc.wisc.edu`). 
-2. **Choose a folder:** Navigate to the folder in CHTC (`/staging` or `/home`) where your output files are located. 
-3. **Connect to ResearchDrive:** Run the following command to connect to ResearchDrive, filling in the username of 
-your PI: 
-    ```
-    [alice@server]$ smbclient -k //research.drive.wisc.edu/PI-Name
-    ```
-    {:.term}
-
-4. **Navigate to appropriate ResearchDrive directory**
-    ```
-    smb: \> cd path/to/directory
-    ```
-    {:.term}
-
-5. **Turn off Prompting**
-    ```
-    smb: \> prompt
-    ```
-    {:.term}
-
-6. **Use `mput` instead of `put`**
-    ```
-    smb: \> mput *.tar.gz
-    ```
-    {:.term}
+        ```
+        smb: \> mput *.tar.gz
+        ```
+        {:.term}
 
 ## Related pages
 * [Log in to CHTC](connecting)


### PR DESCRIPTION
I merged the introduction with the beginning paragraph, added the table of contents, and related pages as mentioned in the style guide, as well as new headers that mimic the "Transfer Files between CHTC and your Computer" completed guide. 