### PR TITLE
Update Gemfile from 2.7.2 to 4.0.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,4 +159,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.7.2
+  4.0.3


### PR DESCRIPTION
When running `docker compose up`, it automatically updates Gemfile.lock to 4.0.3. I'm making the change permanent so I stop seeing this file as "modified" when making commits.