### PR TITLE
Edits to checkpointing guide

### DIFF
--- a/_uw-research-computing/checkpointing.md
+++ b/_uw-research-computing/checkpointing.md
@@ -9,6 +9,8 @@ guide:
         - htc
 ---
 
+## Introduction
+
 Some jobs may take many hours or even days to finish. If one of these jobs is interrupted or reaches a runtime limit, it could **lose all of its progress** and need to start over.
 
 Checkpointing lets the job save its progress along the way, so it can **continue from a saved point** instead of restarting from the beginning.
@@ -21,6 +23,7 @@ On the HTC system, this is especially useful for jobs that might exceed the **72
 This page explains how it works, whether your project is a good fit, and how to set it up.
 
 {% capture content %}
+- [Introduction](#introduction)
 - [Try this example: Counting Fibonacci numbers](#try-this-example-counting-fibonacci-numbers)
 - [How does checkpointing work?](#how-does-checkpointing-work)
 - [Is my project a good fit for checkpointing?](#is-my-project-a-good-fit-for-checkpointing)

--- a/_uw-research-computing/checkpointing.md
+++ b/_uw-research-computing/checkpointing.md
@@ -13,38 +13,34 @@ Some jobs may take many hours or even days to finish. If one of these jobs is in
 
 Checkpointing lets the job save its progress along the way, so it can **continue from a saved point** instead of restarting from the beginning.
 
-On the HTC system, this is especially useful for jobs that might exceed the **72-hour default runtime limit** and/or running on shared or backfill resources (e.g. for <a href="https://chtc.cs.wisc.edu/uw-research-computing/scaling-htc.html">`want_campus_pools` or `want_ospool` jobs</a>), where a job may be evicted before it finishes. 
+<p style="text-align:center"><img src="/images/checkpointing-exit-driven.jpg" alt="The process and steps of exit-driven checkpointing" width=950px>
+</p>
+
+On the HTC system, this is especially useful for jobs that might exceed the **72-hour default runtime limit** or are running on shared or backfill resources (e.g. [`want_campus_pools` or `want_ospool`](scaling-htc.html), [`+is_resumable`](gpu-jobs)), where a job may be evicted before it finishes. 
 
 This page explains how it works, whether your project is a good fit, and how to set it up.
 
 {% capture content %}
-- [Example: Fibonacci](#example-fibonacci)
-   * [Step 1: Download script](#step-1-download-script)
-   * [Step 2: Make the script executable](#step-2-make-the-script-executable)
-   * [Step 3: Create a submit file](#step-3-create-a-submit-file)
-   * [Step 4: Submit the job](#step-4-submit-the-job)
-   * [Step 5: Check the job status](#step-5-check-the-job-status)
-   * [Step 6: Monitor the job](#step-6-monitor-the-job)
-   * [Step 7: Review the results](#step-7-review-the-results)
-   * [How does the script create checkpoints?](#how-does-the-script-create-checkpoints)
+- [Try this example: Counting Fibonacci numbers](#try-this-example-counting-fibonacci-numbers)
 - [How does checkpointing work?](#how-does-checkpointing-work)
 - [Is my project a good fit for checkpointing?](#is-my-project-a-good-fit-for-checkpointing)
 - [How do I set it up?](#how-do-i-set-it-up)
-   * [Make sure your program can checkpoint](#make-sure-your-program-can-checkpoint)
+   * [Make sure your executable script can checkpoint](#make-sure-your-executable-script-can-checkpoint)
    * [Changes to the submit file](#changes-to-the-submit-file)
-- [When do I need a wrapper script?](#when-do-i-need-a-wrapper-script)
+- [Write a time-based wrapper script](#write-a-time-based-wrapper-script)
    * [Create a wrapper script](#create-a-wrapper-script)
    * [Changes to the submit file](#changes-to-the-submit-file-1)
 - [How do I check the progress of my checkpointing job(s)?](#how-do-i-check-the-progress-of-my-checkpointing-jobs)
-- [More Information](#more-information)
+   * [Run a test by evicting your job](#run-a-test-by-evicting-your-job)
+- [Related pages](#related-pages)
 {% endcapture %}
 {% include /components/directory.html title="Table of Contents" %}
 
-## Example: Fibonacci
+## Try this example: Counting Fibonacci numbers
 
-The example below walks you through the checkpointing process step by step. It shows how a program saves its progress, exits, and resumes from a checkpoint so you can apply the same ideas to your own project.
+The example below walks you through the checkpointing process step-by-step. It shows how a program saves its progress, exits, and resumes from a checkpoint so you can apply the same ideas to your own project.
 
-This example uses a Python script that calculates Fibonacci numbers over 10 iterations. Because the calculation is normally very fast, the script pauses for 30 seconds during each iteration to represent a longer-running job. It creates a checkpoint after every two completed iterations.
+This example uses a Python script that calculates Fibonacci numbers over 10 iterations. It creates a checkpoint after every two completed iterations.
 
 ### Step 1: Download script
 
@@ -53,18 +49,21 @@ Log in to your CHTC account through the terminal and download the example script
 ```
 wget https://chtc.cs.wisc.edu/uw-research-computing/files/fibonacci.py
 ```
+{:.term}
 
 Confirm that the file was downloaded:
 
 ```
 ls
 ```
+{:.term}
 
 You should see:
 
 ```
 fibonacci.py
 ```
+{:.term}
 
 ### Step 2: Make the script executable
 
@@ -73,14 +72,16 @@ Before you can run the script directly, give it permission to execute:
 ```
 chmod +x fibonacci.py
 ```
+{:.term}
 
 ### Step 3: Create a submit file
 
-Create a submit file named `fibonacci.sub`. This example uses nano but you can use any text editor you prefer.
+Create a submit file named `fibonacci.sub`. This example uses `nano` but you can use any text editor you prefer.
 
 ```
 nano fibonacci.sub
 ```
+{:.term}
 
 Add the following contents:
 
@@ -92,10 +93,6 @@ arguments = 10
 
 checkpoint_exit_code = 85
 transfer_checkpoint_files = fibonacci.checkpoint
-+is_resumable = true
-
-should_transfer_fileS = YES
-when_to_transfer_output = ON_EXIT
 
 output = fibonacci.out
 error = fibonacci.err
@@ -108,14 +105,12 @@ request_memory = 2GB
 queue
 ```
 
-Save the file and exit the text editor.
+Save the file and exit the text editor. (In `nano`, use `CTRL`+`X` to quit. You will be prompted to save the file before exiting.)
 
 From the **submit file** above, you may have noticed a few additional lines beyond those used for a standard job:
 
-- `checkpoint_exit_code = 85` tells HTCondor that the program saved a checkpoint and should be placed back in the queue. Exit `code 85` is used for all exit-driven checkpointing jobs
-- `transfer_checkpoint_files = fibonacci.checkpoint` identifies the file that will contain the job’s saved progress. Replace `fibonacci.checkpoint` with the name of the checkpoint file or files created by your program
-- `+is_resumable = true` marks the job as able to resume from saved progress
-- `when_to_transfer_output = ON_EXIT` tells HTCondor to transfer the job’s files whenever the program exits, including after it creates a checkpoint
+- `checkpoint_exit_code = 85` tells HTCondor that the program saved a checkpoint and should be placed back in the queue. Exit code `85` is used for all exit-driven checkpointing jobs.
+- `transfer_checkpoint_files = fibonacci.checkpoint` identifies the file that will contain the job’s saved progress. Replace `fibonacci.checkpoint` with the name of the checkpoint file(s) created by your program.
 
 ### Step 4: Submit the job
 
@@ -124,6 +119,7 @@ Submit the job to HTCondor:
 ```
 condor_submit fibonacci.sub
 ```
+{:.term}
 
 The command will return a job ID that you can use to monitor the job.
 
@@ -134,6 +130,7 @@ Use the following command to check whether the job is idle, running, or complete
 ```
 condor_watch_q
 ```
+{:.term}
 
 After each checkpoint, the job may briefly return to the idle state before HTCondor starts it again.
 
@@ -144,6 +141,7 @@ You may follow the HTCondor log while the job runs:
 ```
 tail -n 100 -f fibonacci.log
 ```
+{:.term}
 
 The log records when HTCondor transfers files, starts the job, receives a checkpoint, and restarts the job.
 
@@ -152,6 +150,7 @@ You can also follow the program's output:
 ```
 tail -f fibonacci.out
 ```
+{:.term}
 
 Press `Ctrl+C` to stop following a file. This does not stop the job.
 
@@ -162,6 +161,7 @@ After the job finishes, list the files in the directory:
 ```
 ls
 ```
+{:.term}
 
 You should see files similar to:
 
@@ -180,6 +180,7 @@ View the final result:
 ```
 cat fibonacci.result
 ```
+{:.term}
 
 You should see:
 
@@ -205,7 +206,7 @@ The following parts of `fibonacci.py` control how the script saves and resumes i
 ```
 CHECKPOINT_FILENAME = 'fibonacci.checkpoint'
 
-# Number of seconds to sleep (do nothing) between outer loop iterations
+# Number of seconds to sleep between iterations so the job is visible in the queue
 SLEEP_SECONDS = 30
 
 # Number of outer loop iterations to complete before self-checkpointing
@@ -214,6 +215,9 @@ CHECKPOINT_FREQUENCY = 2
 
 - `CHECKPOINT_FILENAME` sets the name of the file used to save progress.
 - `CHECKPOINT_FREQUENCY` tells the script to create a checkpoint after every two completed iterations. The 30-second pause makes the short calculation behave more like a longer-running job.
+
+
+**Write a check to see if we're starting from scratch or from a checkpoint**
 
 ```
 # Figure out where to start from
@@ -256,19 +260,13 @@ At CHTC, we recommend **exit-driven checkpointing**. With this method, the progr
 
 <p style="text-align:center"><img src="/images/checkpointing-exit-driven.jpg" alt="The process and steps of exit driven checkpointing" width=950px></p>
 
-1. After submitting the job(s) succesfully, it runs until it reaches a checkpoint.
-
-2. The job exits on purpose with checkpoint exit code `85`.
-
-3. HTCondor recognizes code `85` and saves the checkpoint files in a protected directory called `/spool`.
-
-4. HTCondor places the job back in the queue to wait for another execution resource.
-
-5. When the job starts again, HTCondor transfers the checkpoint files from `/spool` back to the job.
-
-6. The program reads the checkpoint files and continues from the saved point.
-
-7. This process repeats until the job finishes and exits normally with code `0`.
+1. After submitting the job(s) successfully, it runs until it reaches a checkpoint.
+1. The job exits on purpose with checkpoint exit code `85`.
+1. HTCondor recognizes code `85` and saves the checkpoint files in a protected directory called `/spool`.
+1. HTCondor places the job back in the queue to wait for another execution resource.
+1. When the job starts again, HTCondor transfers the checkpoint files from `/spool` back to the job.
+1. The program reads the checkpoint files and continues from the saved point.
+1. This process repeats until the job finishes and exits normally with code `0`.
 
 ## Is my project a good fit for checkpointing?
 
@@ -280,11 +278,11 @@ If you are not sure, contact a <a href="https://chtc.cs.wisc.edu/uw-research-com
 
 ## How do I set it up?
 
-Checkpointing requires changes to both your **program** and your **HTCondor submit file**. Your program must be able to save its progress, read the saved files when it starts again, and continue from the saved point.
+Checkpointing requires changes to both your **executable script** and your **HTCondor submit file**. Your executable script must be able to save its progress, read the saved files when it starts again, and continue from the saved point.
 
-### Make sure your program can checkpoint
+### Make sure your executable script can checkpoint
 
-Before updating the submit file, confirm that your program can:
+Before updating the submit file, confirm that your executable script can:
 
 - Save its progress to one or more checkpoint files.
 - Read existing checkpoint files when it starts.
@@ -298,8 +296,6 @@ Checkpointing requires a few additional settings beyond those used for a standar
 
 - `checkpoint_exit_code = 85` tells HTCondor that the program saved a checkpoint and should be placed back in the queue.
 - `transfer_checkpoint_files` lists the checkpoint files or directories that HTCondor must preserve between runs.
-- `+is_resumable = true` identifies the job as able to resume from saved progress.
-- `when_to_transfer_output = ON_EXIT` tells HTCondor to transfer files whenever the program exits, including after a checkpoint.
 
 The submit file may look like this:
 
@@ -311,10 +307,6 @@ arguments = argument1 argument2
 
 checkpoint_exit_code = 85
 transfer_checkpoint_files = my_output.txt, temp_dir, temp_file.txt
-+is_resumable = true
-
-should_transfer_files = YES
-when_to_transfer_output = ON_EXIT
 
 output = example.out
 error = example.err
@@ -329,7 +321,7 @@ queue
 
 Replace the example values with the executable, arguments, checkpoint files, output filenames, and resource requests used by your project.
 
-## When do I need a wrapper script?
+## Write a time-based wrapper script
 
 A wrapper script can be useful when your program creates checkpoint files but **does not** stop on its own after saving them.
 
@@ -405,7 +397,7 @@ If the program finishes before the time limit or exits with an error, the wrappe
 
 When the job starts again, HTCondor returns the saved checkpoint files so `do_science` can resume from its most recent saved point.
 
-### Changes to the`submit file
+### Changes to the submit file
 
 When using a wrapper, set the wrapper script as the **executable** in your submit file. Because the program command and arguments are already included in this wrapper, you **do not** need an arguments line.
 
@@ -416,10 +408,6 @@ executable = my_wrapper.sh
 
 checkpoint_exit_code = 85
 transfer_checkpoint_files = my_output.txt, temp_dir, temp_file.txt
-+is_resumable = true
-
-should_transfer_files = yes
-when_to_transfer_output = ON_EXIT
 
 output = example.out
 error = example.err
@@ -440,10 +428,41 @@ Always test a single checkpointing job before scaling up to identify odd or unin
 
 To determine if your job is successfully creating and saving checkpoint files, you can investigate checkpoint files once they have been transferred to `/spool`.
 
-You can explore the checkpointed files in `/spool` by navigating to `/var/lib/condor/spool`. The directories in this folder are the last four digits of a job's cluster ID with leading zeros removed. Sub folders are labeled with the process ID for each job. For example, to investigate the checkpoint files for `17870068.220`, the files in `/spool` would be found in folder `68` in a subdirectory called `220`.
+1. Navigate to `/var/lib/condor/spool`.
 
-It is also possible to intentionally evict a running job and have it rematch to an execute server to test if your code is successfully resuming from checkpoint files or not. To test this, use `condor_vacate_job <JobID>`. This command will evict your job intentionally and have it return to "Idle" state in the queue. This job will begin running once it rematches to an execute server, allowing you to test if your job is correctly resuming from checkpoint files or incorrectly starting over with the analysis.  
+    ```
+    [user@ap2002 ~]$ cd /var/lib/condor/spool
+    [user@ap2002 spool]$ ls -p
+    1084/  2340/  3913/  549/   7633/  7683/  7694/  800/   checkpoint-cleanup/  schedd_daemon_history
+    1572/  2369/  3914/  550/   7676/  7684/  7695/  8353/  epoch_history        schedd_daemon_history.20260728T215929
+    1968/  2406/  4138/  586/   7677/  7685/  7696/  8455/  history              spool_version
+    2018/  2544/  4251/  6069/  7678/  7686/  7697/  8510/  library.db
+    2325/  2829/  4253/  6130/  7679/  7687/  7698/  8566/  library.db-shm
+    2327/  2997/  4624/  6854/  7680/  7688/  7699/  9019/  library.db-wal
+    2336/  3231/  538/   7550/  7681/  7689/  7700/  9463/  local_univ_execute/
+    2338/  3610/  546/   7591/  7682/  7693/  7701/  9592/  lost+found/
+    ```
+    {:.term}
 
-## More Information
+    The directories in this folder are the **last four digits of a job's cluster ID** with leading zeros removed. **Sub folders are labeled with the process ID for each job**.
+    
+1. To investigate the checkpoint files, look at your job's ID and navigate to the correct directory. 
+    
+    For example, for `17870068.220`, navigate to the directory `68` in a subdirectory called `220`.
+
+    ```
+    [user@ap2002 spool]$ cd 68
+    [user@ap2002 68]$ cd 220
+    ```
+    {:.term}
+
+### Run a test by evicting your job
+
+It is also possible to intentionally evict a running job and have it rematch to an execute server to test if your code is successfully resuming from checkpoint files or not.
+
+1. To test this, use `condor_vacate_job <JobID>`. This command will evict your job intentionally and have it return to "Idle" state in the queue.
+1. This job will begin running once it rematches to an execute server, allowing you to test if your job is correctly resuming from checkpoint files or incorrectly starting over with the analysis.  
+
+## Related pages
 
 For more information about checkpointing HTCondor jobs, see HTCondor's manual [Self-Checkpointing Applications](https://htcondor.readthedocs.io/en/latest/users-manual/self-checkpointing-applications.html).


### PR DESCRIPTION
Major changes
- Add image in Introduction section
- Shorten TOC
- Format some code blocks to terminal-style
- Removed unnecessary submit file options
   - `is_resumable`
   - `should_transfer_files`
   - `when_to_transfer_output`
- Reformatted "How do I check the progress of my checkpointing job(s)?" section to be less of a paragraph, more of a demo