### PR TITLE
Add chtc-announcements email list

### DIFF
--- a/_data/user-portal-menu.yaml
+++ b/_data/user-portal-menu.yaml
@@ -16,6 +16,8 @@
       url: /events.html
     - text: Bioinformatics Café
       url: /uw-research-computing/bioinformatics-cafe
+    - text: Sign up for our email list
+      url: /uw-research-computing/email-list
 - name: About and information
   links:
     - text: About

--- a/_uw-research-computing/email-list.md
+++ b/_uw-research-computing/email-list.md
@@ -1,0 +1,29 @@
+---
+highlighter: none
+layout: markdown-page
+title: Sign up for our email list!
+---
+
+Stay up-to-date with CHTC announcements, events, resources, and other research computing opportunities by signing up for our email list.
+
+We send 1-3 emails a month through this email list.
+
+Important system-wide notices and alerts are sent separately through a different email list.
+
+<div class="d-flex mb-3">
+	<div class="p-3 m-auto">
+		<a class="btn btn-primary" href="https://groups.google.com/a/g-groups.wisc.edu/g/chtc-announcements/membership">Manage your email subscription</a>
+	</div>
+</div>
+
+## How to sign up
+
+1. Go to the [chtc-announcements Google Groups page](https://groups.google.com/a/g-groups.wisc.edu/g/chtc-announcements/).
+1. Click on the **Join Group** button near the top.
+1. Keep or change your notification preferences (we recommend "Each email" — we email only a few times per month) and click **Join group** to confirm.
+
+## How to unsubscribe
+
+1. Go to the [chtc-announcements Google Groups membership page](https://groups.google.com/a/g-groups.wisc.edu/g/chtc-announcements/membership).
+1. Click on the **Leave group** button near the top.
+1. Confirm by clicking **Yes, leave group**.

--- a/events.html
+++ b/events.html
@@ -13,6 +13,7 @@ title: Events
                     </div>
                 {% endfor %}
             </div>
+            <p>Sign up for our <a href="/uw-research-computing/email-list">email list</a> to get notified about upcoming events and trainings!</p>
             {% include get/past_events.liquid %}
             {% if past_events.size > 0 %}
                 <h1 class="text-muted">Past Events</h1>


### PR DESCRIPTION
- Created a new page for users to sign up for our chtc-announcements email list.
- Added link to the new page from the user portal
- Added link to the new page from main Events page